### PR TITLE
fix: increase token limits for chat input and user message

### DIFF
--- a/apps/web/src/app/main/chat/Chat.tsx
+++ b/apps/web/src/app/main/chat/Chat.tsx
@@ -17,7 +17,7 @@ import { UserInput } from './UserInput';
 
 export type MyMessage = UIMessage<MessageMetadata>;
 
-const ASK_TOKEN_LIMIT = 4500;
+const ASK_TOKEN_LIMIT = 10000;
 const USER_PROMPT_ID = 'user-prompt';
 
 export const Chat = () => {

--- a/apps/web/src/app/main/chat/UserInput.tsx
+++ b/apps/web/src/app/main/chat/UserInput.tsx
@@ -101,7 +101,7 @@ export const UserInput = ({ stop, sendMessage, status }: UserInputProps) => {
             value={input}
             onChange={onChange}
             onKeyDown={handleKeyDown}
-            maxLength={2500}
+            maxLength={5000}
             className='max-h-48 min-h-8 scroll-py-2 border-0 rounded-none shadow-none focus-visible:ring-0 p-0 pr-14'
           />
         </div>


### PR DESCRIPTION
### Title
Raise prompt limits; switch to type-only imports

### Changes
- Increased ASK_TOKEN_LIMIT: 4500 → 10000
- Increased input maxLength: 2500 → 5000
- Converted imports to type-only for UIMessage and MessageMetadata

### Why
- Enable longer prompts; Enable more accurate answer; cleaner type usage

### Impact
- Potentially higher token usage and latency