### PR TITLE
feat: add local skills scanning foundation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,5 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   // rust analyzer path settings.
-  "rust-analyzer.linkedProjects": ["apps/tauri/src-tauri/Cargo.toml"]
+  "rust-analyzer.linkedProjects": ["apps/rig/src-tauri/Cargo.toml"]
 }

--- a/apps/rig/package.json
+++ b/apps/rig/package.json
@@ -41,6 +41,7 @@
     "@types/hast": "^3.0.4",
     "ai": "catalog:ai",
     "dompurify": "^3.3.0",
+    "effect": "^3.21.2",
     "es-toolkit": "^1.44.0",
     "fzf": "^0.5.2",
     "jotai": "^2.19.1",

--- a/apps/rig/src-tauri/Cargo.lock
+++ b/apps/rig/src-tauri/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "dotenvy",
  "font-kit",
  "futures",
+ "gray_matter",
  "log",
  "open",
  "rand 0.8.5",
@@ -30,6 +31,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -144,6 +146,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -1212,6 +1220,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "font-kit"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gray_matter"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
+dependencies = [
+ "serde",
+ "thiserror 2.0.17",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,9 +1792,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -6528,6 +6571,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/apps/rig/src-tauri/Cargo.toml
+++ b/apps/rig/src-tauri/Cargo.toml
@@ -41,3 +41,5 @@ url = "2"
 reqwest = { version = "0.12", features = ["json"] }
 font-kit = "0.14"
 shellexpand = "3.1.2"
+walkdir = "2.5.0"
+gray_matter = "0.3.2"

--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod app_updates;
 
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, RunEvent, WindowEvent};
+mod skills;
 
 const OPEN_APP_UPDATE_EVENT: &str = "open-app-update";
 const CHECK_FOR_UPDATES_MENU_ID: &str = "check-for-updates";

--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -95,6 +95,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             app_updates::fetch_update,
             app_updates::install_update,
+            skills::commands::list_skill_roots,
+            skills::commands::list_skills,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/apps/rig/src-tauri/src/skills/commands.rs
+++ b/apps/rig/src-tauri/src/skills/commands.rs
@@ -1,0 +1,53 @@
+use super::models::{Skill, SkillRoot, SkillRootDefinition};
+use super::scanner::list_skills_from_root;
+use crate::skills::fs::expand_path;
+
+pub const SKILL_ROOT_DEFINITIONS: &[SkillRootDefinition] = &[
+    SkillRootDefinition {
+        id: "agents-global",
+        path: "~/.agents/skills",
+        label: "Agents Global Skills",
+    },
+    SkillRootDefinition {
+        id: "opencode-global",
+        path: "~/.config/opencode/skills",
+        label: "OpenCode Global Skills",
+    },
+    SkillRootDefinition {
+        id: "claude-global",
+        path: "~/.claude/skills",
+        label: "Claude Global Skills",
+    },
+];
+
+#[tauri::command]
+pub fn list_skill_roots() -> Vec<SkillRoot> {
+    SKILL_ROOT_DEFINITIONS
+        .iter()
+        .map(|definition| {
+            let path = expand_path(definition.path);
+
+            SkillRoot {
+                id: definition.id.to_string(),
+                path: path.to_string_lossy().to_string(),
+                label: definition.label.to_string(),
+                exists: path.exists(),
+            }
+        })
+        .collect()
+}
+
+#[tauri::command]
+pub fn list_skills(root_path: String) -> Result<Vec<Skill>, String> {
+    let path = expand_path(root_path.as_str());
+
+    if !path.exists() {
+        return Err(format!("Skill root path does not exist: {}", root_path));
+    }
+
+    if !path.is_dir() {
+        return Err(format!("Skill root path is not a directory: {}", root_path));
+    }
+
+    return list_skills_from_root(&path);
+}

--- a/apps/rig/src-tauri/src/skills/fs.rs
+++ b/apps/rig/src-tauri/src/skills/fs.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+pub fn expand_path(path: &str) -> PathBuf {
+    PathBuf::from(shellexpand::tilde(path).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_tilde_path() {
+        let home = std::env::var("HOME").unwrap();
+        let expanded = expand_path("~/.agents/skills");
+
+        assert_eq!(expanded, PathBuf::from(home).join(".agents/skills"));
+    }
+
+    #[test]
+    fn keeps_absolute_path_unchanged() {
+        let path = PathBuf::from("/Users/gaki2/Documents/agents/skills");
+        let expanded = expand_path("/Users/gaki2/Documents/agents/skills");
+        assert_eq!(expanded, path);
+    }
+
+    #[test]
+    fn keeps_relative_path_unchanged() {
+        let path = PathBuf::from("agents/skills");
+        let expanded = expand_path("agents/skills");
+        assert_eq!(expanded, path);
+
+        let path = PathBuf::from("./agents/skills");
+        let expanded = expand_path("./agents/skills");
+        assert_eq!(expanded, path);
+    }
+}

--- a/apps/rig/src-tauri/src/skills/mod.rs
+++ b/apps/rig/src-tauri/src/skills/mod.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/apps/rig/src-tauri/src/skills/mod.rs
+++ b/apps/rig/src-tauri/src/skills/mod.rs
@@ -1,1 +1,5 @@
+pub mod commands;
+pub mod fs;
 pub mod models;
+pub mod parser;
+pub mod scanner;

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -1,0 +1,47 @@
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillRoot {
+    pub id: String,
+    pub path: String,
+    pub label: String,
+    pub exists: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Skill {
+    pub id: String,
+    pub name: String,
+    pub root_path: String,
+    pub relative_path: String,
+    pub has_skill_file: bool,
+    pub description: Option<String>,
+    pub is_valid: bool,
+    pub validation_errors: Vec<SkillValidationError>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillDetail {
+    pub skill: Skill,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SkillValidationErrorCode {
+    MissingSkillFile,
+    EmptySkillFile,
+    InvalidUtf8,
+    ReadFailed,
+    NotDirectory,
+    OutsideRoot,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillValidationError {
+    pub code: SkillValidationErrorCode,
+    pub message: String,
+}

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -1,3 +1,9 @@
+pub struct SkillRootDefinition {
+    pub id: &'static str,
+    pub path: &'static str,
+    pub label: &'static str,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SkillRoot {
@@ -14,18 +20,11 @@ pub struct Skill {
     pub name: String,
     pub root_path: String,
     pub relative_path: String,
-    pub has_skill_file: bool,
+    pub content: String,
     pub description: Option<String>,
     pub is_valid: bool,
-    pub validation_errors: Vec<SkillValidationError>,
+    pub validation_error: Option<SkillValidationError>,
     pub updated_at: Option<String>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SkillDetail {
-    pub skill: Skill,
-    pub content: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -33,10 +32,13 @@ pub struct SkillDetail {
 pub enum SkillValidationErrorCode {
     MissingSkillFile,
     EmptySkillFile,
+    EmptyContent,
     InvalidUtf8,
     ReadFailed,
     NotDirectory,
     OutsideRoot,
+    MissingFrontMatter,
+    InvalidFrontMatter,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/apps/rig/src-tauri/src/skills/parser.rs
+++ b/apps/rig/src-tauri/src/skills/parser.rs
@@ -1,0 +1,156 @@
+use gray_matter::engine::YAML;
+use gray_matter::Matter;
+use serde::Deserialize;
+
+use super::models::{SkillValidationError, SkillValidationErrorCode};
+
+#[derive(Debug)]
+pub struct ParsedSkillFile {
+    pub name: String,
+    pub description: Option<String>,
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillFrontMatter {
+    name: String,
+    description: String,
+}
+
+pub fn parse_skill_file_content(content: &str) -> Result<ParsedSkillFile, SkillValidationError> {
+    if content.trim().is_empty() {
+        return Err(SkillValidationError {
+            code: SkillValidationErrorCode::EmptySkillFile,
+            message: "SKILL.md is empty".to_string(),
+        });
+    }
+
+    let matter = Matter::<YAML>::new();
+    let parsed =
+        matter
+            .parse::<SkillFrontMatter>(content)
+            .map_err(|error| SkillValidationError {
+                code: SkillValidationErrorCode::InvalidFrontMatter,
+                message: format!("Failed to parse SKILL.md frontmatter: {}", error),
+            })?;
+
+    let frontmatter = parsed.data.ok_or_else(|| SkillValidationError {
+        code: SkillValidationErrorCode::MissingFrontMatter,
+        message: "SKILL.md is missing frontmatter".to_string(),
+    })?;
+
+    if frontmatter.name.trim().is_empty() {
+        return Err(SkillValidationError {
+            code: SkillValidationErrorCode::InvalidFrontMatter,
+            message: "SKILL.md frontmatter must include a name".to_string(),
+        });
+    }
+
+    if frontmatter.description.trim().is_empty() {
+        return Err(SkillValidationError {
+            code: SkillValidationErrorCode::InvalidFrontMatter,
+            message: "SKILL.md frontmatter must include a description".to_string(),
+        });
+    }
+
+    let content = parsed.content.trim().to_string();
+
+    if content.is_empty() {
+        return Err(SkillValidationError {
+            code: SkillValidationErrorCode::EmptyContent,
+            message: "SKILL.md content is empty".to_string(),
+        });
+    }
+
+    Ok(ParsedSkillFile {
+        name: frontmatter.name,
+        description: Some(frontmatter.description),
+        content,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_skill_file() {
+        let content = r#"---
+name: Test Skill
+description: Test description
+---
+Use this skill for testing.
+"#;
+
+        let parsed = parse_skill_file_content(content).unwrap();
+
+        assert_eq!(parsed.name, "Test Skill");
+        assert_eq!(parsed.description, Some("Test description".to_string()));
+        assert_eq!(parsed.content, "Use this skill for testing.");
+    }
+
+    #[test]
+    fn returns_empty_skill_file_for_blank_content() {
+        let error = parse_skill_file_content("   \n\t").unwrap_err();
+
+        assert!(matches!(
+            error.code,
+            SkillValidationErrorCode::EmptySkillFile
+        ));
+    }
+
+    #[test]
+    fn returns_missing_frontmatter_when_frontmatter_is_absent() {
+        let error = parse_skill_file_content("Use this skill for testing.").unwrap_err();
+
+        assert!(matches!(
+            error.code,
+            SkillValidationErrorCode::MissingFrontMatter
+        ));
+    }
+
+    #[test]
+    fn returns_invalid_frontmatter_when_name_is_missing() {
+        let content = r#"---
+description: Test description
+---
+Use this skill for testing.
+"#;
+
+        let error = parse_skill_file_content(content).unwrap_err();
+
+        assert!(matches!(
+            error.code,
+            SkillValidationErrorCode::InvalidFrontMatter
+        ));
+    }
+
+    #[test]
+    fn returns_invalid_frontmatter_when_description_is_missing() {
+        let content = r#"---
+name: Test Skill
+---
+Use this skill for testing.
+"#;
+
+        let error = parse_skill_file_content(content).unwrap_err();
+
+        assert!(matches!(
+            error.code,
+            SkillValidationErrorCode::InvalidFrontMatter
+        ));
+    }
+
+    #[test]
+    fn returns_empty_content_when_body_is_missing() {
+        let content = r#"---
+name: Test Skill
+description: Test description
+---
+"#;
+
+        let error = parse_skill_file_content(content).unwrap_err();
+
+        assert!(matches!(error.code, SkillValidationErrorCode::EmptyContent));
+    }
+}

--- a/apps/rig/src-tauri/src/skills/scanner.rs
+++ b/apps/rig/src-tauri/src/skills/scanner.rs
@@ -1,0 +1,109 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use walkdir::{DirEntry, WalkDir};
+
+use super::models::{Skill, SkillValidationError, SkillValidationErrorCode};
+use super::parser::parse_skill_file_content;
+
+const IGNORED_DIRECTORY_NAMES: &[&str] = &[".archive", ".backups", ".git", "node_modules"];
+
+pub fn list_skills_from_root(root_path: &Path) -> Result<Vec<Skill>, String> {
+    let skill_files = collect_skill_files(root_path)?;
+
+    Ok(skill_files
+        .iter()
+        .map(|skill_file_path| build_skill_from_file(root_path, skill_file_path))
+        .collect())
+}
+
+fn collect_skill_files(root_path: &Path) -> Result<Vec<PathBuf>, String> {
+    WalkDir::new(root_path)
+        .into_iter()
+        .filter_entry(should_visit_entry)
+        .filter_map(|entry| match entry {
+            Ok(entry) if is_skill_file(&entry) => Some(Ok(entry.path().to_path_buf())),
+            Ok(_) => None,
+            Err(error) => Some(Err(error.to_string())),
+        })
+        .collect()
+}
+
+fn should_visit_entry(entry: &DirEntry) -> bool {
+    if !entry.file_type().is_dir() {
+        return true;
+    }
+
+    let Some(name) = entry.file_name().to_str() else {
+        return true;
+    };
+
+    !IGNORED_DIRECTORY_NAMES.contains(&name)
+}
+
+fn is_skill_file(entry: &DirEntry) -> bool {
+    entry.file_type().is_file() && entry.file_name() == "SKILL.md"
+}
+
+fn build_skill_from_file(root_path: &Path, skill_file_path: &Path) -> Skill {
+    let skill_dir = skill_file_path.parent().unwrap_or(root_path);
+    let relative_path = skill_dir
+        .strip_prefix(root_path)
+        .unwrap_or(skill_dir)
+        .to_string_lossy()
+        .to_string();
+    let fallback_name = skill_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown-skill")
+        .to_string();
+    let updated_at = skill_file_path
+        .metadata()
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .map(|modified| {
+            let datetime: chrono::DateTime<chrono::Utc> = modified.into();
+            datetime.to_rfc3339()
+        });
+
+    match fs::read_to_string(skill_file_path) {
+        Ok(file_content) => match parse_skill_file_content(&file_content) {
+            Ok(parsed) => Skill {
+                id: relative_path.clone(),
+                name: parsed.name,
+                root_path: root_path.to_string_lossy().to_string(),
+                relative_path,
+                content: parsed.content,
+                description: parsed.description,
+                is_valid: true,
+                validation_error: None,
+                updated_at,
+            },
+            Err(validation_error) => Skill {
+                id: relative_path.clone(),
+                name: fallback_name,
+                root_path: root_path.to_string_lossy().to_string(),
+                relative_path,
+                content: file_content,
+                description: None,
+                is_valid: false,
+                validation_error: Some(validation_error),
+                updated_at,
+            },
+        },
+        Err(error) => Skill {
+            id: relative_path.clone(),
+            name: fallback_name,
+            root_path: root_path.to_string_lossy().to_string(),
+            relative_path,
+            content: String::new(),
+            description: None,
+            is_valid: false,
+            validation_error: Some(SkillValidationError {
+                code: SkillValidationErrorCode::ReadFailed,
+                message: format!("Failed to read SKILL.md: {}", error),
+            }),
+            updated_at,
+        },
+    }
+}

--- a/apps/rig/src/features/skills/api.ts
+++ b/apps/rig/src/features/skills/api.ts
@@ -1,0 +1,87 @@
+import { invoke } from '@tauri-apps/api/core';
+import { Data, Effect } from 'effect';
+import {
+  type SkillDetail,
+  SkillDetailSchema,
+  SkillRootSchema,
+  SkillSchema,
+} from './types';
+
+export class ListSkillRootsError extends Data.TaggedError(
+  'ListSkillRootsError',
+)<{
+  kind: 'InvokeError' | 'ZodParseError';
+  cause: unknown;
+}> {}
+
+export const listSkillRoots = Effect.fn('listSkillRoots')(function* () {
+  const result = yield* Effect.tryPromise({
+    try: () => invoke<unknown>('list_skill_roots'),
+    catch: error =>
+      new ListSkillRootsError({ kind: 'InvokeError', cause: error }),
+  });
+
+  return yield* Effect.try({
+    try: () => SkillRootSchema.array().parse(result),
+    catch: error =>
+      new ListSkillRootsError({ kind: 'ZodParseError', cause: error }),
+  });
+});
+
+export class ListSkillsError extends Data.TaggedError('ListSkillsError')<{
+  kind: 'InvokeError' | 'ZodParseError';
+  rootPath: string;
+  cause: unknown;
+}> {}
+
+export const listSkills = Effect.fn('listSkills')(function* (rootPath: string) {
+  const result = yield* Effect.tryPromise({
+    try: () => invoke<unknown>('list_skills', { rootPath }),
+    catch: error =>
+      new ListSkillsError({ kind: 'InvokeError', rootPath, cause: error }),
+  });
+
+  return yield* Effect.try({
+    try: () => SkillSchema.array().parse(result),
+    catch: error =>
+      new ListSkillsError({
+        kind: 'ZodParseError',
+        rootPath,
+        cause: error,
+      }),
+  });
+});
+
+export class ReadSkillError extends Data.TaggedError('ReadSkillError')<{
+  kind: 'InvokeError' | 'ZodParseError';
+  rootPath: string;
+  relativePath: string;
+  cause: unknown;
+}> {}
+
+export const readSkill = Effect.fn('readSkill')(function* (input: {
+  rootPath: string;
+  relativePath: string;
+}) {
+  const result = yield* Effect.tryPromise({
+    try: () => invoke<unknown>('read_skill', input),
+    catch: error =>
+      new ReadSkillError({
+        kind: 'InvokeError',
+        rootPath: input.rootPath,
+        relativePath: input.relativePath,
+        cause: error,
+      }),
+  });
+
+  return yield* Effect.try({
+    try: () => SkillDetailSchema.parse(result),
+    catch: error =>
+      new ReadSkillError({
+        kind: 'ZodParseError',
+        rootPath: input.rootPath,
+        relativePath: input.relativePath,
+        cause: error,
+      }),
+  });
+});

--- a/apps/rig/src/features/skills/api.ts
+++ b/apps/rig/src/features/skills/api.ts
@@ -1,11 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { Data, Effect } from 'effect';
-import {
-  type SkillDetail,
-  SkillDetailSchema,
-  SkillRootSchema,
-  SkillSchema,
-} from './types';
+import { SkillRootSchema, SkillSchema } from './types';
 
 export class ListSkillRootsError extends Data.TaggedError(
   'ListSkillRootsError',
@@ -47,40 +42,6 @@ export const listSkills = Effect.fn('listSkills')(function* (rootPath: string) {
       new ListSkillsError({
         kind: 'ZodParseError',
         rootPath,
-        cause: error,
-      }),
-  });
-});
-
-export class ReadSkillError extends Data.TaggedError('ReadSkillError')<{
-  kind: 'InvokeError' | 'ZodParseError';
-  rootPath: string;
-  relativePath: string;
-  cause: unknown;
-}> {}
-
-export const readSkill = Effect.fn('readSkill')(function* (input: {
-  rootPath: string;
-  relativePath: string;
-}) {
-  const result = yield* Effect.tryPromise({
-    try: () => invoke<unknown>('read_skill', input),
-    catch: error =>
-      new ReadSkillError({
-        kind: 'InvokeError',
-        rootPath: input.rootPath,
-        relativePath: input.relativePath,
-        cause: error,
-      }),
-  });
-
-  return yield* Effect.try({
-    try: () => SkillDetailSchema.parse(result),
-    catch: error =>
-      new ReadSkillError({
-        kind: 'ZodParseError',
-        rootPath: input.rootPath,
-        relativePath: input.relativePath,
         cause: error,
       }),
   });

--- a/apps/rig/src/features/skills/types.ts
+++ b/apps/rig/src/features/skills/types.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+export const SkillRootSchema = z.object({
+  id: z.string(),
+  path: z.string(),
+  label: z.string(),
+  exists: z.boolean(),
+});
+
+export const SkillValidationErrorCodeSchema = z.enum([
+  'missingSkillFile',
+  'emptySkillFile',
+  'invalidUtf8',
+  'readFailed',
+  'notDirectory',
+  'outsideRoot',
+]);
+
+export const SkillValidationErrorSchema = z.object({
+  code: SkillValidationErrorCodeSchema,
+  message: z.string(),
+});
+
+export const SkillRootErrorCodeSchema = z.enum([
+  'invalidRootPath',
+  'rootNotDirectory',
+  'permissionDenied',
+  'readFailed',
+  'pathOutsideAllowedRoots',
+]);
+
+export const SkillRootErrorSchema = z.object({
+  code: SkillRootErrorCodeSchema,
+  message: z.string(),
+  rootPath: z.string(),
+});
+
+export const SkillSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  rootPath: z.string(),
+  relativePath: z.string(),
+  hasSkillFile: z.boolean(),
+  description: z.string().nullable(),
+  isValid: z.boolean(),
+  validationErrors: z.array(SkillValidationErrorSchema),
+  updatedAt: z.string().nullable(),
+});
+
+export const SkillDetailSchema = z.object({
+  skill: SkillSchema,
+  content: z.string(),
+});
+
+export type SkillRoot = z.infer<typeof SkillRootSchema>;
+export type SkillValidationErrorCode = z.infer<
+  typeof SkillValidationErrorCodeSchema
+>;
+export type SkillValidationError = z.infer<typeof SkillValidationErrorSchema>;
+export type SkillRootErrorCode = z.infer<typeof SkillRootErrorCodeSchema>;
+export type SkillRootError = z.infer<typeof SkillRootErrorSchema>;
+export type Skill = z.infer<typeof SkillSchema>;
+export type SkillDetail = z.infer<typeof SkillDetailSchema>;

--- a/apps/rig/src/features/skills/types.ts
+++ b/apps/rig/src/features/skills/types.ts
@@ -10,10 +10,13 @@ export const SkillRootSchema = z.object({
 export const SkillValidationErrorCodeSchema = z.enum([
   'missingSkillFile',
   'emptySkillFile',
+  'emptyContent',
   'invalidUtf8',
   'readFailed',
   'notDirectory',
   'outsideRoot',
+  'missingFrontMatter',
+  'invalidFrontMatter',
 ]);
 
 export const SkillValidationErrorSchema = z.object({
@@ -40,16 +43,11 @@ export const SkillSchema = z.object({
   name: z.string(),
   rootPath: z.string(),
   relativePath: z.string(),
-  hasSkillFile: z.boolean(),
+  content: z.string(),
   description: z.string().nullable(),
   isValid: z.boolean(),
-  validationErrors: z.array(SkillValidationErrorSchema),
+  validationError: SkillValidationErrorSchema.nullable(),
   updatedAt: z.string().nullable(),
-});
-
-export const SkillDetailSchema = z.object({
-  skill: SkillSchema,
-  content: z.string(),
 });
 
 export type SkillRoot = z.infer<typeof SkillRootSchema>;
@@ -60,4 +58,3 @@ export type SkillValidationError = z.infer<typeof SkillValidationErrorSchema>;
 export type SkillRootErrorCode = z.infer<typeof SkillRootErrorCodeSchema>;
 export type SkillRootError = z.infer<typeof SkillRootErrorSchema>;
 export type Skill = z.infer<typeof SkillSchema>;
-export type SkillDetail = z.infer<typeof SkillDetailSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       dompurify:
         specifier: ^3.3.0
         version: 3.3.0
+      effect:
+        specifier: ^3.21.2
+        version: 3.21.2
       es-toolkit:
         specifier: ^1.44.0
         version: 1.44.0
@@ -4541,6 +4544,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   electron-to-chromium@1.5.245:
     resolution: {integrity: sha512-rdmGfW47ZhL/oWEJAY4qxRtdly2B98ooTJ0pdEI4jhVLZ6tNf8fPtov2wS1IRKwFJT92le3x4Knxiwzl7cPPpQ==}
 
@@ -4829,6 +4835,10 @@ packages:
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -6414,6 +6424,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -12385,6 +12398,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.245: {}
 
   embla-carousel-react@8.6.0(react@19.2.1):
@@ -12609,8 +12627,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.28.0(jiti@2.4.2))
@@ -12632,7 +12650,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -12643,22 +12661,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.7.11
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.28.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12669,7 +12687,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12883,6 +12901,10 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -14961,6 +14983,8 @@ snapshots:
   property-information@7.0.0: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   quansync@0.2.11: {}
 


### PR DESCRIPTION
## Summary
- Add Rust models and Tauri commands for listing configured skill roots and scanning local SKILL.md files
- Parse SKILL.md frontmatter with gray_matter and discover files with walkdir
- Add frontend Zod schemas and Effect-based APIs for listSkillRoots/listSkills
- Add parser unit tests and keep scanner tests for a later pass

## Testing
- cargo fmt && cargo check
- cargo test skills::parser
- pnpm --filter desktop-app check-ts

## Notes
- This branch also includes the existing app rename/cleanup commits already present on feat/skills-models.