### PR TITLE
Add skill usage tracking and sidebar metrics

### DIFF
--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -98,6 +98,7 @@ pub fn run() {
             skills::commands::list_skill_roots,
             skills::commands::list_skills,
             skills::commands::list_skill_usages,
+            skills::commands::list_skill_usages_tendency,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -97,6 +97,7 @@ pub fn run() {
             app_updates::install_update,
             skills::commands::list_skill_roots,
             skills::commands::list_skills,
+            skills::commands::list_skill_usages,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/apps/rig/src-tauri/src/skills/commands.rs
+++ b/apps/rig/src-tauri/src/skills/commands.rs
@@ -1,9 +1,9 @@
 use super::models::{
-    Skill, SkillListingError, SkillRoot, SkillRootDefinition, SkillUsage, SkillUsageError,
-    WindowType,
+    BucketType, Skill, SkillListingError, SkillRoot, SkillRootDefinition, SkillUsage,
+    SkillUsageError, SkillUsageSeries, WindowType,
 };
 use super::scanner::list_skills_from_root;
-use super::usage::list_skill_usages_from_log;
+use super::usage::{list_skill_usage_tendencies_from_log, list_skill_usages_from_log};
 use crate::skills::fs::expand_path;
 use crate::skills::models::SkillListingErrorCode;
 
@@ -70,4 +70,18 @@ pub fn list_skill_usages(window: Option<WindowType>) -> Result<Vec<SkillUsage>, 
     let path = expand_path(SKILL_USAGE_LOG_PATH);
 
     list_skill_usages_from_log(&path, window.unwrap_or(WindowType::Day))
+}
+
+#[tauri::command]
+pub fn list_skill_usages_tendency(
+    window: Option<WindowType>,
+    bucket_type: Option<BucketType>,
+) -> Result<Vec<SkillUsageSeries>, SkillUsageError> {
+    let path = expand_path(SKILL_USAGE_LOG_PATH);
+
+    list_skill_usage_tendencies_from_log(
+        &path,
+        window.unwrap_or(WindowType::Week),
+        bucket_type.unwrap_or(BucketType::Hour),
+    )
 }

--- a/apps/rig/src-tauri/src/skills/commands.rs
+++ b/apps/rig/src-tauri/src/skills/commands.rs
@@ -1,7 +1,13 @@
-use super::models::{Skill, SkillListingError, SkillRoot, SkillRootDefinition};
+use super::models::{
+    Skill, SkillListingError, SkillRoot, SkillRootDefinition, SkillUsage, SkillUsageError,
+    WindowType,
+};
 use super::scanner::list_skills_from_root;
+use super::usage::list_skill_usages_from_log;
 use crate::skills::fs::expand_path;
 use crate::skills::models::SkillListingErrorCode;
+
+const SKILL_USAGE_LOG_PATH: &str = "~/rig-usage.jsonl";
 
 pub const SKILL_ROOT_DEFINITIONS: &[SkillRootDefinition] = &[
     SkillRootDefinition {
@@ -57,4 +63,11 @@ pub fn list_skills(root_path: String) -> Result<Vec<Skill>, SkillListingError> {
     }
 
     return list_skills_from_root(&path);
+}
+
+#[tauri::command]
+pub fn list_skill_usages(window: Option<WindowType>) -> Result<Vec<SkillUsage>, SkillUsageError> {
+    let path = expand_path(SKILL_USAGE_LOG_PATH);
+
+    list_skill_usages_from_log(&path, window.unwrap_or(WindowType::Day))
 }

--- a/apps/rig/src-tauri/src/skills/mod.rs
+++ b/apps/rig/src-tauri/src/skills/mod.rs
@@ -3,3 +3,4 @@ pub mod fs;
 pub mod models;
 pub mod parser;
 pub mod scanner;
+pub mod usage;

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -73,14 +73,6 @@ pub struct SkillUsageLogSchema {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SkillUsage {
-    pub name: String,
-    pub count: u32,
-    pub last_used_at: Option<String>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub enum WindowType {
     Day,
     Week,
@@ -90,8 +82,31 @@ pub enum WindowType {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub enum BucketType {
+    Hour,
+    Day,
+    Month,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum SkillUsageErrorCode {
     ReadFailed,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillUsage {
+    pub name: String,
+    pub count: u32,
+    pub last_used_at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillUsageSeries {
+    pub name: String,
+    pub series: Vec<u32>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -62,3 +62,41 @@ pub struct SkillListingError {
     pub code: SkillListingErrorCode,
     pub message: String,
 }
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillUsageLogSchema {
+    pub source: String,
+    pub skill_name: String,
+    pub used_at: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillUsage {
+    pub name: String,
+    pub count: u32,
+    pub last_used_at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WindowType {
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SkillUsageErrorCode {
+    ReadFailed,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillUsageError {
+    pub code: SkillUsageErrorCode,
+    pub message: String,
+}

--- a/apps/rig/src-tauri/src/skills/usage.rs
+++ b/apps/rig/src-tauri/src/skills/usage.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 use chrono::{DateTime, Duration, Utc};
 
 use super::models::{
-    SkillUsage, SkillUsageError, SkillUsageErrorCode, SkillUsageLogSchema, WindowType,
+    BucketType, SkillUsage, SkillUsageError, SkillUsageErrorCode, SkillUsageLogSchema,
+    SkillUsageSeries, WindowType,
 };
 
 struct SkillUsageEvent {
@@ -21,6 +22,21 @@ pub fn list_skill_usages_from_log(
     let events = read_skill_usage_events(path)?;
 
     Ok(summarize_skill_usages(events, window, Utc::now()))
+}
+
+pub fn list_skill_usage_tendencies_from_log(
+    path: &Path,
+    window: WindowType,
+    bucket_type: BucketType,
+) -> Result<Vec<SkillUsageSeries>, SkillUsageError> {
+    let events = read_skill_usage_events(path)?;
+
+    Ok(build_skill_usage_tendencies(
+        events,
+        window,
+        bucket_type,
+        Utc::now(),
+    ))
 }
 
 fn read_skill_usage_events(path: &Path) -> Result<Vec<SkillUsageEvent>, SkillUsageError> {
@@ -113,4 +129,58 @@ fn usage_window_start(now: DateTime<Utc>, window: WindowType) -> DateTime<Utc> {
         WindowType::Month => now - Duration::days(30),
         WindowType::Year => now - Duration::days(365),
     }
+}
+
+fn build_skill_usage_tendencies(
+    events: Vec<SkillUsageEvent>,
+    window: WindowType,
+    bucket_type: BucketType,
+    now: DateTime<Utc>,
+) -> Vec<SkillUsageSeries> {
+    let start = usage_window_start(now, window);
+    let bucket_duration = bucket_duration(bucket_type);
+    let bucket_count = bucket_count(start, now, bucket_duration);
+    let mut tendencies = HashMap::<String, Vec<u32>>::new();
+
+    for event in events {
+        if event.used_at < start || event.used_at > now {
+            continue;
+        }
+
+        let bucket_index =
+            ((event.used_at - start).num_seconds() / bucket_duration.num_seconds()) as usize;
+
+        if bucket_index >= bucket_count {
+            continue;
+        }
+
+        let series = tendencies
+            .entry(event.skill_name)
+            .or_insert_with(|| vec![0; bucket_count]);
+
+        series[bucket_index] += 1;
+    }
+
+    let mut tendencies = tendencies
+        .into_iter()
+        .map(|(name, series)| SkillUsageSeries { name, series })
+        .collect::<Vec<_>>();
+
+    tendencies.sort_by(|a, b| a.name.cmp(&b.name));
+    tendencies
+}
+
+fn bucket_duration(bucket_type: BucketType) -> Duration {
+    match bucket_type {
+        BucketType::Hour => Duration::hours(1),
+        BucketType::Day => Duration::days(1),
+        BucketType::Month => Duration::days(30),
+    }
+}
+
+fn bucket_count(start: DateTime<Utc>, end: DateTime<Utc>, bucket_duration: Duration) -> usize {
+    let seconds = (end - start).num_seconds();
+    let bucket_seconds = bucket_duration.num_seconds();
+
+    ((seconds + bucket_seconds - 1) / bucket_seconds) as usize
 }

--- a/apps/rig/src-tauri/src/skills/usage.rs
+++ b/apps/rig/src-tauri/src/skills/usage.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use chrono::{DateTime, Duration, Utc};
+
+use super::models::{
+    SkillUsage, SkillUsageError, SkillUsageErrorCode, SkillUsageLogSchema, WindowType,
+};
+
+struct SkillUsageEvent {
+    skill_name: String,
+    used_at: DateTime<Utc>,
+}
+
+pub fn list_skill_usages_from_log(
+    path: &Path,
+    window: WindowType,
+) -> Result<Vec<SkillUsage>, SkillUsageError> {
+    let events = read_skill_usage_events(path)?;
+
+    Ok(summarize_skill_usages(events, window, Utc::now()))
+}
+
+fn read_skill_usage_events(path: &Path) -> Result<Vec<SkillUsageEvent>, SkillUsageError> {
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+
+    let file = File::open(path).map_err(|error| SkillUsageError {
+        code: SkillUsageErrorCode::ReadFailed,
+        message: format!("Failed to open skill usage log: {}", error),
+    })?;
+
+    let reader = BufReader::new(file);
+
+    Ok(reader
+        .lines()
+        .filter_map(Result::ok)
+        .filter_map(|line| parse_skill_usage_event(&line))
+        .collect())
+}
+
+fn parse_skill_usage_event(line: &str) -> Option<SkillUsageEvent> {
+    let line = line.trim();
+
+    if line.is_empty() {
+        return None;
+    }
+
+    let log = serde_json::from_str::<SkillUsageLogSchema>(line).ok()?;
+    let used_at = DateTime::parse_from_rfc3339(&log.used_at)
+        .ok()?
+        .with_timezone(&Utc);
+
+    Some(SkillUsageEvent {
+        skill_name: log.skill_name,
+        used_at,
+    })
+}
+
+fn summarize_skill_usages(
+    events: Vec<SkillUsageEvent>,
+    window: WindowType,
+    now: DateTime<Utc>,
+) -> Vec<SkillUsage> {
+    let start = usage_window_start(now, window);
+    let mut usages = HashMap::<String, SkillUsage>::new();
+
+    for event in events {
+        if event.used_at < start || event.used_at > now {
+            continue;
+        }
+
+        update_skill_usage(&mut usages, event);
+    }
+
+    let mut usages = usages.into_values().collect::<Vec<_>>();
+    usages.sort_by(|a, b| a.name.cmp(&b.name));
+    usages
+}
+
+fn update_skill_usage(usages: &mut HashMap<String, SkillUsage>, event: SkillUsageEvent) {
+    let used_at = event
+        .used_at
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+    let usage = usages
+        .entry(event.skill_name.clone())
+        .or_insert(SkillUsage {
+            name: event.skill_name,
+            count: 0,
+            last_used_at: None,
+        });
+
+    usage.count += 1;
+
+    if usage
+        .last_used_at
+        .as_ref()
+        .map(|last_used_at| used_at > *last_used_at)
+        .unwrap_or(true)
+    {
+        usage.last_used_at = Some(used_at);
+    }
+}
+
+fn usage_window_start(now: DateTime<Utc>, window: WindowType) -> DateTime<Utc> {
+    match window {
+        WindowType::Day => now - Duration::hours(24),
+        WindowType::Week => now - Duration::days(7),
+        WindowType::Month => now - Duration::days(30),
+        WindowType::Year => now - Duration::days(365),
+    }
+}

--- a/apps/rig/src/features/skills/api.ts
+++ b/apps/rig/src/features/skills/api.ts
@@ -1,6 +1,15 @@
 import { invoke } from '@tauri-apps/api/core';
 import { Data, Effect } from 'effect';
-import { SkillListingErrorSchema, SkillRootSchema, SkillSchema } from './types';
+import {
+  SkillListingErrorSchema,
+  SkillRootSchema,
+  SkillSchema,
+  SkillUsageErrorSchema,
+  SkillUsageSchema,
+  SkillUsageSeriesSchema,
+  type BucketType,
+  type WindowType,
+} from './types';
 
 export class ListSkillRootsError extends Data.TaggedError(
   'ListSkillRootsError',
@@ -73,6 +82,91 @@ export const listSkills = Effect.fn('listSkills')(function* (rootPath: string) {
       new ListSkillsError({
         kind: 'ZodParseError',
         rootPath,
+        cause: error,
+      }),
+  });
+});
+
+export class ListSkillUsagesError extends Data.TaggedError(
+  'ListSkillUsagesError',
+)<{
+  kind: 'InvokeError' | 'SkillUsageError' | 'ZodParseError';
+  cause: unknown;
+}> {}
+
+export const listSkillUsages = Effect.fn('listSkillUsages')(function* (
+  window?: WindowType,
+) {
+  const result = yield* Effect.tryPromise({
+    try: () => invoke<unknown>('list_skill_usages', { window }),
+    catch: error => error,
+  }).pipe(
+    Effect.catchAll(error => {
+      const usageError = SkillUsageErrorSchema.safeParse(error);
+
+      if (usageError.success) {
+        return Effect.fail(
+          new ListSkillUsagesError({
+            kind: 'SkillUsageError',
+            cause: usageError.data,
+          }),
+        );
+      }
+
+      return Effect.fail(
+        new ListSkillUsagesError({ kind: 'InvokeError', cause: error }),
+      );
+    }),
+  );
+
+  return yield* Effect.try({
+    try: () => SkillUsageSchema.array().parse(result),
+    catch: error =>
+      new ListSkillUsagesError({ kind: 'ZodParseError', cause: error }),
+  });
+});
+
+export class ListSkillUsagesTendencyError extends Data.TaggedError(
+  'ListSkillUsagesTendencyError',
+)<{
+  kind: 'InvokeError' | 'SkillUsageError' | 'ZodParseError';
+  cause: unknown;
+}> {}
+
+export const listSkillUsagesTendency = Effect.fn(
+  'listSkillUsagesTendency',
+)(function* (window?: WindowType, bucketType?: BucketType) {
+  const result = yield* Effect.tryPromise({
+    try: () =>
+      invoke<unknown>('list_skill_usages_tendency', { window, bucketType }),
+    catch: error => error,
+  }).pipe(
+    Effect.catchAll(error => {
+      const usageError = SkillUsageErrorSchema.safeParse(error);
+
+      if (usageError.success) {
+        return Effect.fail(
+          new ListSkillUsagesTendencyError({
+            kind: 'SkillUsageError',
+            cause: usageError.data,
+          }),
+        );
+      }
+
+      return Effect.fail(
+        new ListSkillUsagesTendencyError({
+          kind: 'InvokeError',
+          cause: error,
+        }),
+      );
+    }),
+  );
+
+  return yield* Effect.try({
+    try: () => SkillUsageSeriesSchema.array().parse(result),
+    catch: error =>
+      new ListSkillUsagesTendencyError({
+        kind: 'ZodParseError',
         cause: error,
       }),
   });

--- a/apps/rig/src/features/skills/components/SkillList.tsx
+++ b/apps/rig/src/features/skills/components/SkillList.tsx
@@ -1,6 +1,9 @@
 import { Badge, cn, ScrollArea } from '@allin/ui';
+import { useState } from 'react';
 import type { Skill, SkillUsage, SkillUsageSeries } from '../types';
 import { SkillUsageSparkline } from './SkillUsageSparkline';
+
+type SkillSortKey = 'fires' | 'name';
 
 export interface SkillListProps {
   skills: Skill[];
@@ -21,6 +24,8 @@ export const SkillList = ({
   error,
   onSelectSkill,
 }: SkillListProps) => {
+  const [sortKey, setSortKey] = useState<SkillSortKey>('fires');
+
   if (isLoading) {
     return (
       <div className='space-y-2 p-3'>
@@ -52,61 +57,96 @@ export const SkillList = ({
   const tendencyByName = new Map(
     skillUsageTendencies.map(tendency => [tendency.name, tendency]),
   );
+  const totalFires = skillUsages.reduce(
+    (total, usage) => total + usage.count,
+    0,
+  );
+  const sortedSkills = skills.toSorted((a, b) => {
+    if (sortKey === 'name') {
+      return a.name.localeCompare(b.name);
+    }
+
+    const aCount = usageByName.get(a.name)?.count ?? 0;
+    const bCount = usageByName.get(b.name)?.count ?? 0;
+
+    return bCount - aCount || a.name.localeCompare(b.name);
+  });
 
   return (
-    <ScrollArea className='h-full'>
-      <div className='space-y-1 p-3'>
-        {skills.map(skill => {
-          const isSelected = selectedSkill?.id === skill.id;
-          const usage = usageByName.get(skill.name);
-          const tendency = tendencyByName.get(skill.name);
-          const count = usage?.count ?? 0;
+    <div className='flex h-full min-h-0 flex-col'>
+      <div className='shrink-0 border-b px-5 py-4'>
+        <div className='flex items-baseline gap-2'>
+          <h2 className='text-xl font-semibold tracking-tight'>Skills</h2>
+          <p className='text-sm text-muted-foreground'>
+            {skills.length} skills · {totalFires} fires
+          </p>
+        </div>
 
-          return (
-            <button
-              key={skill.id}
-              type='button'
-              aria-current={isSelected ? 'true' : undefined}
-              onClick={() => onSelectSkill(skill)}
-              className={cn(
-                'flex w-full min-w-0 items-center gap-3 rounded-xl border px-3 py-3 text-left transition-colors',
-                'hover:bg-accent hover:text-accent-foreground',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                isSelected
-                  ? 'border-primary bg-accent text-accent-foreground'
-                  : 'border-transparent bg-transparent',
-              )}
-            >
-              <SkillUsageSparkline values={tendency?.series ?? []} />
-
-              <span className='min-w-0 flex-1'>
-                <span className='flex min-w-0 items-center gap-2'>
-                  <span className='truncate text-sm font-medium'>
-                    {skill.name}
-                  </span>
-                  {!skill.isValid && (
-                    <Badge
-                      variant='destructive'
-                      className='h-5 px-1.5 text-[10px]'
-                    >
-                      Invalid
-                    </Badge>
-                  )}
-                </span>
-
-                <span className='mt-1 line-clamp-1 text-xs text-muted-foreground'>
-                  {skill.description || skill.relativePath}
-                </span>
-              </span>
-
-              <span className='shrink-0 text-sm font-light tabular-nums'>
-                {count}
-                <span className='text-xs text-muted-foreground'>×</span>
-              </span>
-            </button>
-          );
-        })}
+        <div className='mt-4 flex items-center gap-2 text-sm'>
+          <span className='text-muted-foreground'>Sorted by</span>
+          <button
+            type='button'
+            onClick={() => setSortKey(sortKey === 'fires' ? 'name' : 'fires')}
+            className='font-medium text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+          >
+            {sortKey === 'fires' ? 'fires ↓' : 'name ↑'}
+          </button>
+        </div>
       </div>
-    </ScrollArea>
+      <ScrollArea className='min-h-0 flex-1'>
+        <div className='space-y-1 p-3'>
+          {sortedSkills.map(skill => {
+            const isSelected = selectedSkill?.id === skill.id;
+            const usage = usageByName.get(skill.name);
+            const tendency = tendencyByName.get(skill.name);
+            const count = usage?.count ?? 0;
+
+            return (
+              <button
+                key={skill.id}
+                type='button'
+                aria-current={isSelected ? 'true' : undefined}
+                onClick={() => onSelectSkill(skill)}
+                className={cn(
+                  'flex w-full min-w-0 items-center gap-3 rounded-xl border px-3 py-3 text-left transition-colors',
+                  'hover:bg-accent hover:text-accent-foreground',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  isSelected
+                    ? 'border-primary bg-accent text-accent-foreground'
+                    : 'border-transparent bg-transparent',
+                )}
+              >
+                <SkillUsageSparkline values={tendency?.series ?? []} />
+
+                <span className='min-w-0 flex-1'>
+                  <span className='flex min-w-0 items-center gap-2'>
+                    <span className='truncate text-sm font-medium'>
+                      {skill.name}
+                    </span>
+                    {!skill.isValid && (
+                      <Badge
+                        variant='destructive'
+                        className='h-5 px-1.5 text-[10px]'
+                      >
+                        Invalid
+                      </Badge>
+                    )}
+                  </span>
+
+                  <span className='mt-1 line-clamp-1 text-xs text-muted-foreground'>
+                    {skill.description || skill.relativePath}
+                  </span>
+                </span>
+
+                <span className='shrink-0 text-sm font-light tabular-nums'>
+                  {count}
+                  <span className='text-xs text-muted-foreground'>×</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </div>
   );
 };

--- a/apps/rig/src/features/skills/components/SkillList.tsx
+++ b/apps/rig/src/features/skills/components/SkillList.tsx
@@ -1,9 +1,12 @@
 import { Badge, cn, ScrollArea } from '@allin/ui';
-import type { Skill } from '../types';
+import type { Skill, SkillUsage, SkillUsageSeries } from '../types';
+import { SkillUsageSparkline } from './SkillUsageSparkline';
 
 export interface SkillListProps {
   skills: Skill[];
   selectedSkill: Skill | null;
+  skillUsages: SkillUsage[];
+  skillUsageTendencies: SkillUsageSeries[];
   isLoading: boolean;
   error: string | null;
   onSelectSkill: (skill: Skill) => void;
@@ -12,6 +15,8 @@ export interface SkillListProps {
 export const SkillList = ({
   skills,
   selectedSkill,
+  skillUsages,
+  skillUsageTendencies,
   isLoading,
   error,
   onSelectSkill,
@@ -43,11 +48,19 @@ export const SkillList = ({
     );
   }
 
+  const usageByName = new Map(skillUsages.map(usage => [usage.name, usage]));
+  const tendencyByName = new Map(
+    skillUsageTendencies.map(tendency => [tendency.name, tendency]),
+  );
+
   return (
     <ScrollArea className='h-full'>
       <div className='space-y-1 p-3'>
         {skills.map(skill => {
           const isSelected = selectedSkill?.id === skill.id;
+          const usage = usageByName.get(skill.name);
+          const tendency = tendencyByName.get(skill.name);
+          const count = usage?.count ?? 0;
 
           return (
             <button
@@ -56,7 +69,7 @@ export const SkillList = ({
               aria-current={isSelected ? 'true' : undefined}
               onClick={() => onSelectSkill(skill)}
               className={cn(
-                'flex w-full min-w-0 flex-col rounded-lg border px-3 py-2 text-left transition-colors',
+                'flex w-full min-w-0 items-center gap-3 rounded-xl border px-3 py-3 text-left transition-colors',
                 'hover:bg-accent hover:text-accent-foreground',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                 isSelected
@@ -64,21 +77,31 @@ export const SkillList = ({
                   : 'border-transparent bg-transparent',
               )}
             >
-              <span className='flex min-w-0 items-center gap-2'>
-                <span className='truncate text-sm font-medium'>
-                  {skill.name}
+              <SkillUsageSparkline values={tendency?.series ?? []} />
+
+              <span className='min-w-0 flex-1'>
+                <span className='flex min-w-0 items-center gap-2'>
+                  <span className='truncate text-sm font-medium'>
+                    {skill.name}
+                  </span>
+                  {!skill.isValid && (
+                    <Badge
+                      variant='destructive'
+                      className='h-5 px-1.5 text-[10px]'
+                    >
+                      Invalid
+                    </Badge>
+                  )}
                 </span>
-                {!skill.isValid && (
-                  <Badge
-                    variant='destructive'
-                    className='h-5 px-1.5 text-[10px]'
-                  >
-                    Invalid
-                  </Badge>
-                )}
+
+                <span className='mt-1 line-clamp-1 text-xs text-muted-foreground'>
+                  {skill.description || skill.relativePath}
+                </span>
               </span>
-              <span className='mt-1 line-clamp-1 text-xs text-muted-foreground'>
-                {skill.description || skill.relativePath}
+
+              <span className='shrink-0 text-sm font-light tabular-nums'>
+                {count}
+                <span className='text-xs text-muted-foreground'>×</span>
               </span>
             </button>
           );

--- a/apps/rig/src/features/skills/components/SkillSidebar.tsx
+++ b/apps/rig/src/features/skills/components/SkillSidebar.tsx
@@ -1,6 +1,6 @@
-import { useQueries } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { Effect } from 'effect';
-import { listSkills } from '../api';
+import { listSkills, listSkillUsages, listSkillUsagesTendency } from '../api';
 import type { Skill, SkillRoot } from '../types';
 import { SkillList } from './SkillList';
 
@@ -22,6 +22,16 @@ export const SkillSidebar = ({
     })),
   });
 
+  const { data: skillUsages = [] } = useQuery({
+    queryKey: ['skill-usages', 'month'],
+    queryFn: () => Effect.runPromise(listSkillUsages('month')),
+  });
+
+  const { data: skillUsageTendencies = [] } = useQuery({
+    queryKey: ['skill-usages-tendency', 'month', 'day'],
+    queryFn: () => Effect.runPromise(listSkillUsagesTendency('month', 'day')),
+  });
+
   const skills = skillQueries.flatMap(query => query.data ?? []);
   const isLoading = skillQueries.some(query => query.isLoading);
   const error = skillQueries.find(query => query.error)?.error;
@@ -30,6 +40,8 @@ export const SkillSidebar = ({
     <SkillList
       skills={skills}
       selectedSkill={selectedSkill}
+      skillUsages={skillUsages}
+      skillUsageTendencies={skillUsageTendencies}
       isLoading={isLoading}
       error={error ? String(error) : null}
       onSelectSkill={onSelectSkill}

--- a/apps/rig/src/features/skills/components/SkillUsageSparkline.tsx
+++ b/apps/rig/src/features/skills/components/SkillUsageSparkline.tsx
@@ -1,0 +1,89 @@
+import { cn } from '@allin/ui';
+
+interface SkillUsageSparklineProps {
+  values: number[];
+  className?: string;
+}
+
+export const SkillUsageSparkline = ({
+  values,
+  className,
+}: SkillUsageSparklineProps) => {
+  const width = 36;
+  const height = 28;
+  const baseline = height / 2;
+  const activeValues = values.filter(value => value > 0);
+
+  if (activeValues.length === 0) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        aria-hidden='true'
+        className={cn(
+          'shrink-0 overflow-visible text-muted-foreground',
+          className,
+        )}
+      >
+        <line
+          x1='0'
+          x2={width}
+          y1={baseline}
+          y2={baseline}
+          stroke='currentColor'
+          strokeDasharray='3 3'
+          strokeLinecap='round'
+          strokeWidth='1'
+          opacity='0.7'
+        />
+      </svg>
+    );
+  }
+
+  const max = Math.max(...values, 1);
+  const step = width / Math.max(values.length, 1);
+  const amplitude = baseline - 3;
+
+  const points = values.flatMap((value, index) => {
+    const startX = index * step;
+    const peakX = startX + step / 2;
+    const endX = startX + step;
+
+    if (value === 0) {
+      return [
+        `${startX.toFixed(2)},${baseline.toFixed(2)}`,
+        `${endX.toFixed(2)},${baseline.toFixed(2)}`,
+      ];
+    }
+
+    const direction = index % 2 === 0 ? -1 : 1;
+    const intensity = value / max;
+    const peakY = baseline + direction * intensity * amplitude;
+
+    return [
+      `${startX.toFixed(2)},${baseline.toFixed(2)}`,
+      `${peakX.toFixed(2)},${peakY.toFixed(2)}`,
+      `${endX.toFixed(2)},${baseline.toFixed(2)}`,
+    ];
+  });
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden='true'
+      className={cn('shrink-0 overflow-visible text-blue-500', className)}
+    >
+      <polyline
+        points={points.join(' ')}
+        fill='none'
+        stroke='currentColor'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        strokeWidth='1'
+      />
+    </svg>
+  );
+};

--- a/apps/rig/src/features/skills/types.ts
+++ b/apps/rig/src/features/skills/types.ts
@@ -35,6 +35,17 @@ export const SkillListingErrorSchema = z.object({
   message: z.string(),
 });
 
+export const SkillUsageErrorCodeSchema = z.enum(['readFailed']);
+
+export const SkillUsageErrorSchema = z.object({
+  code: SkillUsageErrorCodeSchema,
+  message: z.string(),
+});
+
+export const WindowTypeSchema = z.enum(['day', 'week', 'month', 'year']);
+
+export const BucketTypeSchema = z.enum(['hour', 'day', 'month']);
+
 export const SkillSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -47,6 +58,17 @@ export const SkillSchema = z.object({
   updatedAt: z.string().nullable(),
 });
 
+export const SkillUsageSchema = z.object({
+  name: z.string(),
+  count: z.number(),
+  lastUsedAt: z.string().nullable(),
+});
+
+export const SkillUsageSeriesSchema = z.object({
+  name: z.string(),
+  series: z.number().array(),
+});
+
 export type SkillRoot = z.infer<typeof SkillRootSchema>;
 export type SkillValidationErrorCode = z.infer<
   typeof SkillValidationErrorCodeSchema
@@ -55,3 +77,9 @@ export type SkillValidationError = z.infer<typeof SkillValidationErrorSchema>;
 export type SkillListingErrorCode = z.infer<typeof SkillListingErrorCodeSchema>;
 export type SkillListingError = z.infer<typeof SkillListingErrorSchema>;
 export type Skill = z.infer<typeof SkillSchema>;
+export type SkillUsageErrorCode = z.infer<typeof SkillUsageErrorCodeSchema>;
+export type SkillUsageError = z.infer<typeof SkillUsageErrorSchema>;
+export type WindowType = z.infer<typeof WindowTypeSchema>;
+export type BucketType = z.infer<typeof BucketTypeSchema>;
+export type SkillUsage = z.infer<typeof SkillUsageSchema>;
+export type SkillUsageSeries = z.infer<typeof SkillUsageSeriesSchema>;


### PR DESCRIPTION
## Summary
- add `list_skill_usages` and `list_skill_usages_tendency` Tauri commands
- parse OpenCode skill usage JSONL logs into summaries and time buckets
- add frontend usage schemas and Effect APIs
- show skill usage count and heartbeat sparkline in the sidebar
- add sidebar summary with total skills/fires and sorting by fires/name

## Verification
- `cargo fmt && cargo check`
- `pnpm --filter desktop-app check-ts`