### PR TITLE
Add imported skill roots and repository selector

### DIFF
--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -95,6 +95,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             app_updates::fetch_update,
             app_updates::install_update,
+            skills::commands::import_skill_root,
             skills::commands::list_skill_roots,
             skills::commands::list_skills,
             skills::commands::list_skill_usages,

--- a/apps/rig/src-tauri/src/skills/commands.rs
+++ b/apps/rig/src-tauri/src/skills/commands.rs
@@ -1,7 +1,8 @@
 use super::models::{
-    BucketType, Skill, SkillListingError, SkillRoot, SkillRootDefinition, SkillUsage,
-    SkillUsageError, SkillUsageSeries, WindowType,
+    BucketType, Skill, SkillListingError, SkillRoot, SkillRootDefinition, SkillRootImportError,
+    SkillRootKind, SkillUsage, SkillUsageError, SkillUsageSeries, WindowType,
 };
+use super::root_store::{import_skill_root_from_path, list_imported_skill_roots};
 use super::scanner::list_skills_from_root;
 use super::usage::{list_skill_usage_tendencies_from_log, list_skill_usages_from_log};
 use crate::skills::fs::expand_path;
@@ -28,8 +29,8 @@ pub const SKILL_ROOT_DEFINITIONS: &[SkillRootDefinition] = &[
 ];
 
 #[tauri::command]
-pub fn list_skill_roots() -> Vec<SkillRoot> {
-    SKILL_ROOT_DEFINITIONS
+pub fn list_skill_roots(app: tauri::AppHandle) -> Vec<SkillRoot> {
+    let mut roots = SKILL_ROOT_DEFINITIONS
         .iter()
         .map(|definition| {
             let path = expand_path(definition.path);
@@ -39,9 +40,21 @@ pub fn list_skill_roots() -> Vec<SkillRoot> {
                 path: path.to_string_lossy().to_string(),
                 label: definition.label.to_string(),
                 exists: path.exists(),
+                kind: SkillRootKind::Default,
             }
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    roots.extend(list_imported_skill_roots(&app));
+    roots
+}
+
+#[tauri::command]
+pub fn import_skill_root(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<SkillRoot, SkillRootImportError> {
+    import_skill_root_from_path(&app, expand_path(path.as_str()))
 }
 
 #[tauri::command]

--- a/apps/rig/src-tauri/src/skills/mod.rs
+++ b/apps/rig/src-tauri/src/skills/mod.rs
@@ -2,5 +2,6 @@ pub mod commands;
 pub mod fs;
 pub mod models;
 pub mod parser;
+pub mod root_store;
 pub mod scanner;
 pub mod usage;

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -6,11 +6,44 @@ pub struct SkillRootDefinition {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub enum SkillRootKind {
+    Default,
+    Repository,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SkillRoot {
     pub id: String,
     pub path: String,
     pub label: String,
     pub exists: bool,
+    pub kind: SkillRootKind,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportedSkillRoot {
+    pub id: String,
+    pub path: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SkillRootImportErrorCode {
+    PathNotFound,
+    NotDirectory,
+    DuplicateId,
+    ReadFailed,
+    WriteFailed,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillRootImportError {
+    pub code: SkillRootImportErrorCode,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/apps/rig/src-tauri/src/skills/root_store.rs
+++ b/apps/rig/src-tauri/src/skills/root_store.rs
@@ -1,0 +1,140 @@
+use std::fs;
+use std::path::PathBuf;
+
+use tauri::{AppHandle, Manager};
+
+use super::models::{
+    ImportedSkillRoot, SkillRoot, SkillRootImportError, SkillRootImportErrorCode, SkillRootKind,
+};
+
+const SKILL_ROOTS_FILE_NAME: &str = "skill-roots.json";
+
+pub fn list_imported_skill_roots(app: &AppHandle) -> Vec<SkillRoot> {
+    load_imported_skill_roots(app)
+        .unwrap_or_default()
+        .into_iter()
+        .map(imported_skill_root_to_skill_root)
+        .collect()
+}
+
+pub fn import_skill_root_from_path(
+    app: &AppHandle,
+    path: PathBuf,
+) -> Result<SkillRoot, SkillRootImportError> {
+    if !path.exists() {
+        return Err(SkillRootImportError {
+            code: SkillRootImportErrorCode::PathNotFound,
+            message: format!("Skill root path does not exist: {}", path.display()),
+        });
+    }
+
+    if !path.is_dir() {
+        return Err(SkillRootImportError {
+            code: SkillRootImportErrorCode::NotDirectory,
+            message: format!("Skill root path is not a directory: {}", path.display()),
+        });
+    }
+
+    let path = path.canonicalize().map_err(|error| SkillRootImportError {
+        code: SkillRootImportErrorCode::ReadFailed,
+        message: format!("Failed to resolve skill root path: {}", error),
+    })?;
+
+    let label = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+    let path = path.to_string_lossy().to_string();
+
+    let mut imported_roots = load_imported_skill_roots(app)?;
+
+    if let Some(existing) = imported_roots.iter().find(|root| root.path == path) {
+        return Ok(imported_skill_root_to_skill_root(existing.clone()));
+    }
+
+    if imported_roots.iter().any(|root| root.id == label) {
+        return Err(SkillRootImportError {
+            code: SkillRootImportErrorCode::DuplicateId,
+            message: format!("A skill root with id '{}' already exists", label),
+        });
+    }
+
+    let imported = ImportedSkillRoot {
+        id: label.clone(),
+        path,
+        label,
+    };
+
+    imported_roots.push(imported.clone());
+    save_imported_skill_roots(app, &imported_roots)?;
+
+    Ok(imported_skill_root_to_skill_root(imported))
+}
+
+fn load_imported_skill_roots(
+    app: &AppHandle,
+) -> Result<Vec<ImportedSkillRoot>, SkillRootImportError> {
+    let path = skill_roots_file_path(app)?;
+
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+
+    let content = fs::read_to_string(&path).map_err(|error| SkillRootImportError {
+        code: SkillRootImportErrorCode::ReadFailed,
+        message: format!("Failed to read imported skill roots: {}", error),
+    })?;
+
+    serde_json::from_str(&content).map_err(|error| SkillRootImportError {
+        code: SkillRootImportErrorCode::ReadFailed,
+        message: format!("Failed to parse imported skill roots: {}", error),
+    })
+}
+
+fn save_imported_skill_roots(
+    app: &AppHandle,
+    roots: &[ImportedSkillRoot],
+) -> Result<(), SkillRootImportError> {
+    let path = skill_roots_file_path(app)?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| SkillRootImportError {
+            code: SkillRootImportErrorCode::WriteFailed,
+            message: format!("Failed to create skill roots directory: {}", error),
+        })?;
+    }
+
+    let content = serde_json::to_string_pretty(roots).map_err(|error| SkillRootImportError {
+        code: SkillRootImportErrorCode::WriteFailed,
+        message: format!("Failed to serialize imported skill roots: {}", error),
+    })?;
+
+    fs::write(path, content).map_err(|error| SkillRootImportError {
+        code: SkillRootImportErrorCode::WriteFailed,
+        message: format!("Failed to write imported skill roots: {}", error),
+    })
+}
+
+fn skill_roots_file_path(app: &AppHandle) -> Result<PathBuf, SkillRootImportError> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| SkillRootImportError {
+            code: SkillRootImportErrorCode::ReadFailed,
+            message: format!("Failed to resolve app data directory: {}", error),
+        })?;
+
+    Ok(app_data_dir.join(SKILL_ROOTS_FILE_NAME))
+}
+
+fn imported_skill_root_to_skill_root(root: ImportedSkillRoot) -> SkillRoot {
+    let path = PathBuf::from(&root.path);
+
+    SkillRoot {
+        id: root.id,
+        path: root.path,
+        label: root.label,
+        exists: path.exists(),
+        kind: SkillRootKind::Repository,
+    }
+}

--- a/apps/rig/src/app/root.tsx
+++ b/apps/rig/src/app/root.tsx
@@ -1,31 +1,77 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { open } from '@tauri-apps/plugin-dialog';
 import { Effect } from 'effect';
 import { useState } from 'react';
-import { listSkillRoots } from '@/features/skills/api';
+import { importSkillRoot, listSkillRoots } from '@/features/skills/api';
 import { SkillContentViewer } from '@/features/skills/components/SkillContentViewer';
 import { SkillSidebar } from '@/features/skills/components/SkillSidebar';
-import type { Skill } from '@/features/skills/types';
+import {
+  GLOBAL_REPOSITORY_ID,
+  RepositorySelector,
+} from '@/features/skills/components/RepositorySelector';
+import type { Skill, SkillRoot } from '@/features/skills/types';
 import { ContentLayout } from '@/layouts/ContentLayout';
 import { HeaderLayout } from '@/layouts/HeaderLayout';
 import { SidebarLayout } from '@/layouts/SidebarLayout';
 
 export const Root = () => {
+  const queryClient = useQueryClient();
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
+  const [selectedRepositoryId, setSelectedRepositoryId] =
+    useState(GLOBAL_REPOSITORY_ID);
+  const [isRepositorySelectorOpen, setIsRepositorySelectorOpen] =
+    useState(false);
 
-  const { data: rootPaths } = useQuery({
+  const { data: rootPaths = [] } = useQuery({
     queryKey: ['skill-roots'],
     queryFn: () => Effect.runPromise(listSkillRoots()),
   });
 
+  const importRootMutation = useMutation({
+    mutationFn: (path: string) => Effect.runPromise(importSkillRoot(path)),
+    onSuccess: importedRoot => {
+      setSelectedRepositoryId(importedRoot.id);
+      setSelectedSkill(null);
+      setIsRepositorySelectorOpen(false);
+      void queryClient.invalidateQueries({ queryKey: ['skill-roots'] });
+    },
+  });
+
+  const visibleRoots = getVisibleRoots(rootPaths, selectedRepositoryId);
+
+  const handleSelectRepository = (repositoryId: string) => {
+    setSelectedRepositoryId(repositoryId);
+    setSelectedSkill(null);
+    setIsRepositorySelectorOpen(false);
+  };
+
+  const handleImportRepository = async () => {
+    const selectedPath = await open({ directory: true, multiple: false });
+
+    if (typeof selectedPath !== 'string') {
+      return;
+    }
+
+    importRootMutation.mutate(selectedPath);
+  };
+
   return (
     <main className='flex h-dvh flex-col overflow-hidden bg-background text-foreground'>
       <HeaderLayout>
-        <span>Hello</span>
+        <RepositorySelector
+          roots={rootPaths}
+          selectedRepositoryId={selectedRepositoryId}
+          isOpen={isRepositorySelectorOpen}
+          isImporting={importRootMutation.isPending}
+          onOpenChange={setIsRepositorySelectorOpen}
+          onSelectRepository={handleSelectRepository}
+          onImportRepository={handleImportRepository}
+        />
       </HeaderLayout>
       <div className='flex min-h-0 flex-1'>
         <SidebarLayout>
           <SkillSidebar
-            roots={rootPaths ?? []}
+            roots={visibleRoots}
             selectedSkill={selectedSkill}
             onSelectSkill={setSelectedSkill}
           />
@@ -37,4 +83,15 @@ export const Root = () => {
       </div>
     </main>
   );
+};
+
+const getVisibleRoots = (
+  roots: SkillRoot[],
+  selectedRepositoryId: string,
+) => {
+  if (selectedRepositoryId === GLOBAL_REPOSITORY_ID) {
+    return roots.filter(root => root.kind === 'default');
+  }
+
+  return roots.filter(root => root.id === selectedRepositoryId);
 };

--- a/apps/rig/src/features/skills/api.ts
+++ b/apps/rig/src/features/skills/api.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { Data, Effect } from 'effect';
 import {
   SkillListingErrorSchema,
+  SkillRootImportErrorSchema,
   SkillRootSchema,
   SkillSchema,
   SkillUsageErrorSchema,
@@ -29,6 +30,45 @@ export const listSkillRoots = Effect.fn('listSkillRoots')(function* () {
     try: () => SkillRootSchema.array().parse(result),
     catch: error =>
       new ListSkillRootsError({ kind: 'ZodParseError', cause: error }),
+  });
+});
+
+export class ImportSkillRootError extends Data.TaggedError(
+  'ImportSkillRootError',
+)<{
+  kind: 'InvokeError' | 'SkillRootImportError' | 'ZodParseError';
+  cause: unknown;
+}> {}
+
+export const importSkillRoot = Effect.fn('importSkillRoot')(function* (
+  path: string,
+) {
+  const result = yield* Effect.tryPromise({
+    try: () => invoke<unknown>('import_skill_root', { path }),
+    catch: error => error,
+  }).pipe(
+    Effect.catchAll(error => {
+      const importError = SkillRootImportErrorSchema.safeParse(error);
+
+      if (importError.success) {
+        return Effect.fail(
+          new ImportSkillRootError({
+            kind: 'SkillRootImportError',
+            cause: importError.data,
+          }),
+        );
+      }
+
+      return Effect.fail(
+        new ImportSkillRootError({ kind: 'InvokeError', cause: error }),
+      );
+    }),
+  );
+
+  return yield* Effect.try({
+    try: () => SkillRootSchema.parse(result),
+    catch: error =>
+      new ImportSkillRootError({ kind: 'ZodParseError', cause: error }),
   });
 });
 

--- a/apps/rig/src/features/skills/components/RepositorySelector.tsx
+++ b/apps/rig/src/features/skills/components/RepositorySelector.tsx
@@ -1,0 +1,153 @@
+import { cn, Popover, PopoverContent, PopoverTrigger } from '@allin/ui';
+import { Check, ChevronsUpDown, Folder, Home, Plus } from 'lucide-react';
+import type { SkillRoot } from '../types';
+
+const GLOBAL_REPOSITORY_ID = 'global';
+
+interface RepositorySelectorProps {
+  roots: SkillRoot[];
+  selectedRepositoryId: string;
+  isOpen: boolean;
+  isImporting: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSelectRepository: (repositoryId: string) => void;
+  onImportRepository: () => void;
+}
+
+export const RepositorySelector = ({
+  roots,
+  selectedRepositoryId,
+  isOpen,
+  isImporting,
+  onOpenChange,
+  onSelectRepository,
+  onImportRepository,
+}: RepositorySelectorProps) => {
+  const repositoryRoots = roots.filter(root => root.kind === 'repository');
+  const selectedRepository = repositoryRoots.find(
+    root => root.id === selectedRepositoryId,
+  );
+  const selectedLabel = selectedRepository?.label ?? 'Global';
+
+  return (
+    <Popover open={isOpen} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type='button'
+          className='flex h-14 w-78 ml-2 items-center gap-3 rounded-sm px-3 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        >
+          <span className='flex size-8 shrink-0 items-center justify-center rounded-lg bg-foreground text-background'>
+            {selectedRepository ? <Folder size={18} /> : <Home size={18} />}
+          </span>
+          <span className='min-w-0 flex-1'>
+            <span className='block truncate text-sm font-semibold leading-4'>
+              {selectedLabel}
+            </span>
+          </span>
+
+          <ChevronsUpDown size={16} className='shrink-0 text-muted-foreground' />
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align='start'
+        sideOffset={0}
+        className='w-78 shadow-2xl rounded-2xl p-3'
+      >
+        <p className='px-2 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground'>
+          Repository
+        </p>
+
+        <RepositoryOption
+          icon={<Home size={18} />}
+          label='Global'
+          path='Default skill roots'
+          isSelected={selectedRepositoryId === GLOBAL_REPOSITORY_ID}
+          onClick={() => onSelectRepository(GLOBAL_REPOSITORY_ID)}
+        />
+
+        {repositoryRoots.map(root => (
+          <RepositoryOption
+            key={root.id}
+            icon={<Folder size={18} />}
+            label={root.label}
+            path={root.path}
+            isSelected={selectedRepositoryId === root.id}
+            onClick={() => onSelectRepository(root.id)}
+          />
+        ))}
+
+        <div className='my-3 border-t' />
+
+        <button
+          type='button'
+          onClick={onImportRepository}
+          disabled={isImporting}
+          className='flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        >
+          <span className='flex size-9 shrink-0 items-center justify-center rounded-lg border border-dashed bg-background text-muted-foreground'>
+            <Plus size={18} />
+          </span>
+
+          <span className='min-w-0'>
+            <span className='block text-sm font-semibold'>
+              {isImporting ? 'Importing repository...' : 'Import repository...'}
+            </span>
+            <span className='mt-0.5 block font-mono text-xs text-muted-foreground'>
+              From a local folder
+            </span>
+          </span>
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+interface RepositoryOptionProps {
+  icon: React.ReactNode;
+  label: string;
+  path: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const RepositoryOption = ({
+  icon,
+  label,
+  path,
+  isSelected,
+  onClick,
+}: RepositoryOptionProps) => {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isSelected ? 'bg-muted' : 'hover:bg-muted/70',
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-9 shrink-0 items-center justify-center rounded-lg',
+          isSelected
+            ? 'bg-foreground text-background'
+            : 'border bg-background text-foreground',
+        )}
+      >
+        {icon}
+      </span>
+
+      <span className='min-w-0 flex-1'>
+        <span className='block truncate text-sm font-semibold'>{label}</span>
+        <span className='mt-0.5 block truncate font-mono text-xs text-muted-foreground'>
+          {path}
+        </span>
+      </span>
+
+      {isSelected && <Check size={18} className='shrink-0 text-blue-500' />}
+    </button>
+  );
+};
+
+export { GLOBAL_REPOSITORY_ID };

--- a/apps/rig/src/features/skills/types.ts
+++ b/apps/rig/src/features/skills/types.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
 
+export const SkillRootKindSchema = z.enum(['default', 'repository']);
+
 export const SkillRootSchema = z.object({
   id: z.string(),
   path: z.string(),
   label: z.string(),
   exists: z.boolean(),
+  kind: SkillRootKindSchema,
 });
 
 export const SkillValidationErrorCodeSchema = z.enum([
@@ -32,6 +35,19 @@ export const SkillListingErrorCodeSchema = z.enum([
 
 export const SkillListingErrorSchema = z.object({
   code: SkillListingErrorCodeSchema,
+  message: z.string(),
+});
+
+export const SkillRootImportErrorCodeSchema = z.enum([
+  'pathNotFound',
+  'notDirectory',
+  'duplicateId',
+  'readFailed',
+  'writeFailed',
+]);
+
+export const SkillRootImportErrorSchema = z.object({
+  code: SkillRootImportErrorCodeSchema,
   message: z.string(),
 });
 
@@ -70,12 +86,17 @@ export const SkillUsageSeriesSchema = z.object({
 });
 
 export type SkillRoot = z.infer<typeof SkillRootSchema>;
+export type SkillRootKind = z.infer<typeof SkillRootKindSchema>;
 export type SkillValidationErrorCode = z.infer<
   typeof SkillValidationErrorCodeSchema
 >;
 export type SkillValidationError = z.infer<typeof SkillValidationErrorSchema>;
 export type SkillListingErrorCode = z.infer<typeof SkillListingErrorCodeSchema>;
 export type SkillListingError = z.infer<typeof SkillListingErrorSchema>;
+export type SkillRootImportErrorCode = z.infer<
+  typeof SkillRootImportErrorCodeSchema
+>;
+export type SkillRootImportError = z.infer<typeof SkillRootImportErrorSchema>;
 export type Skill = z.infer<typeof SkillSchema>;
 export type SkillUsageErrorCode = z.infer<typeof SkillUsageErrorCodeSchema>;
 export type SkillUsageError = z.infer<typeof SkillUsageErrorSchema>;

--- a/apps/rig/src/layouts/HeaderLayout.tsx
+++ b/apps/rig/src/layouts/HeaderLayout.tsx
@@ -1,6 +1,6 @@
 export const HeaderLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <header className='flex h-14 shrink-0 items-center border-b bg-background px-6'>
+    <header className='flex h-18 shrink-0 items-center border-b bg-background'>
       {children}
     </header>
   );


### PR DESCRIPTION
## Summary
- add persisted imported skill roots storage in Tauri app data
- add `import_skill_root` command and return default + repository roots from `list_skill_roots`
- add frontend schemas and API for imported roots
- add header repository selector with Popover and folder import flow
- filter sidebar roots by selected repository, with Global as the default view

## Verification
- `cargo fmt && cargo check`
- `pnpm --filter desktop-app check-ts`
<img width="3200" height="2000" alt="rig-repository-selector" src="https://github.com/user-attachments/assets/8dec6270-0b1b-40c2-8aa6-b3b46c75a76d" />


<img width="3200" height="2000" alt="rig-repository-selector-open" src="https://github.com/user-attachments/assets/0e08c093-d76e-4082-bd3d-d276e18c4f7a" />

