### PR TITLE
Refactor skill repository state hooks

### DIFF
--- a/apps/rig/src/app/root.tsx
+++ b/apps/rig/src/app/root.tsx
@@ -1,77 +1,45 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { open } from '@tauri-apps/plugin-dialog';
-import { Effect } from 'effect';
 import { useState } from 'react';
-import { importSkillRoot, listSkillRoots } from '@/features/skills/api';
 import { SkillContentViewer } from '@/features/skills/components/SkillContentViewer';
 import { SkillSidebar } from '@/features/skills/components/SkillSidebar';
-import {
-  GLOBAL_REPOSITORY_ID,
-  RepositorySelector,
-} from '@/features/skills/components/RepositorySelector';
-import type { Skill, SkillRoot } from '@/features/skills/types';
+import { RepositorySelector } from '@/features/skills/components/RepositorySelector';
+import type { Skill } from '@/features/skills/types';
+import { useImportSkillRoot } from '@/features/skills/useImportSkillRoot';
+import { useSkillRepositorySelection } from '@/features/skills/useSkillRepositorySelection';
+import { useSkillRoots } from '@/features/skills/useSkillRoots';
 import { ContentLayout } from '@/layouts/ContentLayout';
 import { HeaderLayout } from '@/layouts/HeaderLayout';
 import { SidebarLayout } from '@/layouts/SidebarLayout';
 
 export const Root = () => {
-  const queryClient = useQueryClient();
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
-  const [selectedRepositoryId, setSelectedRepositoryId] =
-    useState(GLOBAL_REPOSITORY_ID);
-  const [isRepositorySelectorOpen, setIsRepositorySelectorOpen] =
-    useState(false);
 
-  const { data: rootPaths = [] } = useQuery({
-    queryKey: ['skill-roots'],
-    queryFn: () => Effect.runPromise(listSkillRoots()),
+  const { data: roots = [] } = useSkillRoots();
+  const repositorySelection = useSkillRepositorySelection({
+    roots,
+    onRepositoryChange: () => setSelectedSkill(null),
   });
-
-  const importRootMutation = useMutation({
-    mutationFn: (path: string) => Effect.runPromise(importSkillRoot(path)),
-    onSuccess: importedRoot => {
-      setSelectedRepositoryId(importedRoot.id);
-      setSelectedSkill(null);
-      setIsRepositorySelectorOpen(false);
-      void queryClient.invalidateQueries({ queryKey: ['skill-roots'] });
-    },
+  const importSkillRoot = useImportSkillRoot({
+    onImported: importedRoot =>
+      repositorySelection.selectRepository(importedRoot.id),
   });
-
-  const visibleRoots = getVisibleRoots(rootPaths, selectedRepositoryId);
-
-  const handleSelectRepository = (repositoryId: string) => {
-    setSelectedRepositoryId(repositoryId);
-    setSelectedSkill(null);
-    setIsRepositorySelectorOpen(false);
-  };
-
-  const handleImportRepository = async () => {
-    const selectedPath = await open({ directory: true, multiple: false });
-
-    if (typeof selectedPath !== 'string') {
-      return;
-    }
-
-    importRootMutation.mutate(selectedPath);
-  };
 
   return (
     <main className='flex h-dvh flex-col overflow-hidden bg-background text-foreground'>
       <HeaderLayout>
         <RepositorySelector
-          roots={rootPaths}
-          selectedRepositoryId={selectedRepositoryId}
-          isOpen={isRepositorySelectorOpen}
-          isImporting={importRootMutation.isPending}
-          onOpenChange={setIsRepositorySelectorOpen}
-          onSelectRepository={handleSelectRepository}
-          onImportRepository={handleImportRepository}
+          roots={roots}
+          selectedRepositoryId={repositorySelection.selectedRepositoryId}
+          isOpen={repositorySelection.isOpen}
+          isImporting={importSkillRoot.isImporting}
+          onOpenChange={repositorySelection.setIsOpen}
+          onSelectRepository={repositorySelection.selectRepository}
+          onImportRepository={importSkillRoot.importFromFolder}
         />
       </HeaderLayout>
       <div className='flex min-h-0 flex-1'>
         <SidebarLayout>
           <SkillSidebar
-            roots={visibleRoots}
+            roots={repositorySelection.visibleRoots}
             selectedSkill={selectedSkill}
             onSelectSkill={setSelectedSkill}
           />
@@ -83,15 +51,4 @@ export const Root = () => {
       </div>
     </main>
   );
-};
-
-const getVisibleRoots = (
-  roots: SkillRoot[],
-  selectedRepositoryId: string,
-) => {
-  if (selectedRepositoryId === GLOBAL_REPOSITORY_ID) {
-    return roots.filter(root => root.kind === 'default');
-  }
-
-  return roots.filter(root => root.id === selectedRepositoryId);
 };

--- a/apps/rig/src/features/skills/useImportSkillRoot.ts
+++ b/apps/rig/src/features/skills/useImportSkillRoot.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { open } from '@tauri-apps/plugin-dialog';
+import { Effect } from 'effect';
+import { importSkillRoot } from './api';
+import type { SkillRoot } from './types';
+import { skillRootsQueryKey } from './useSkillRoots';
+
+export const useImportSkillRoot = ({
+  onImported,
+}: {
+  onImported: (root: SkillRoot) => void;
+}) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (path: string) => Effect.runPromise(importSkillRoot(path)),
+    onSuccess: importedRoot => {
+      onImported(importedRoot);
+      void queryClient.invalidateQueries({ queryKey: skillRootsQueryKey });
+    },
+  });
+
+  const importFromFolder = async () => {
+    const selectedPath = await open({ directory: true, multiple: false });
+
+    if (typeof selectedPath !== 'string') {
+      return;
+    }
+
+    mutation.mutate(selectedPath);
+  };
+
+  return {
+    importFromFolder,
+    isImporting: mutation.isPending,
+  };
+};

--- a/apps/rig/src/features/skills/useSkillRepositorySelection.ts
+++ b/apps/rig/src/features/skills/useSkillRepositorySelection.ts
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { GLOBAL_REPOSITORY_ID } from './components/RepositorySelector';
+import type { SkillRoot } from './types';
+
+export const useSkillRepositorySelection = ({
+  roots,
+  onRepositoryChange,
+}: {
+  roots: SkillRoot[];
+  onRepositoryChange: () => void;
+}) => {
+  const [selectedRepositoryId, setSelectedRepositoryId] =
+    useState(GLOBAL_REPOSITORY_ID);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectRepository = (repositoryId: string) => {
+    setSelectedRepositoryId(repositoryId);
+    setIsOpen(false);
+    onRepositoryChange();
+  };
+
+  return {
+    selectedRepositoryId,
+    visibleRoots: getVisibleRoots(roots, selectedRepositoryId),
+    isOpen,
+    setIsOpen,
+    selectRepository,
+  };
+};
+
+const getVisibleRoots = (
+  roots: SkillRoot[],
+  selectedRepositoryId: string,
+) => {
+  if (selectedRepositoryId === GLOBAL_REPOSITORY_ID) {
+    return roots.filter(root => root.kind === 'default');
+  }
+
+  return roots.filter(root => root.id === selectedRepositoryId);
+};

--- a/apps/rig/src/features/skills/useSkillRoots.ts
+++ b/apps/rig/src/features/skills/useSkillRoots.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { Effect } from 'effect';
+import { listSkillRoots } from './api';
+
+export const skillRootsQueryKey = ['skill-roots'] as const;
+
+export const useSkillRoots = () => {
+  return useQuery({
+    queryKey: skillRootsQueryKey,
+    queryFn: () => Effect.runPromise(listSkillRoots()),
+  });
+};


### PR DESCRIPTION
## Summary
- extract skill roots query into `useSkillRoots`
- extract repository import mutation and folder picker into `useImportSkillRoot`
- extract repository selection state and visible root filtering into `useSkillRepositorySelection`
- simplify `Root` so it only composes layout and feature components

## Verification
- `pnpm --filter desktop-app check-ts`