### PR TITLE
feat: add skill usage dashboard

### DIFF
--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ pub fn run() {
             skills::commands::list_skills,
             skills::commands::list_skill_usages,
             skills::commands::list_skill_usages_tendency,
+            skills::commands::remove_skill_root,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/apps/rig/src-tauri/src/skills/commands.rs
+++ b/apps/rig/src-tauri/src/skills/commands.rs
@@ -2,7 +2,9 @@ use super::models::{
     BucketType, Skill, SkillListingError, SkillRoot, SkillRootDefinition, SkillRootImportError,
     SkillRootKind, SkillUsage, SkillUsageError, SkillUsageSeries, WindowType,
 };
-use super::root_store::{import_skill_root_from_path, list_imported_skill_roots};
+use super::root_store::{
+    import_skill_root_from_path, list_imported_skill_roots, remove_imported_skill_root,
+};
 use super::scanner::list_skills_from_root;
 use super::usage::{list_skill_usage_tendencies_from_log, list_skill_usages_from_log};
 use crate::skills::fs::expand_path;
@@ -55,6 +57,14 @@ pub fn import_skill_root(
     path: String,
 ) -> Result<SkillRoot, SkillRootImportError> {
     import_skill_root_from_path(&app, expand_path(path.as_str()))
+}
+
+#[tauri::command]
+pub fn remove_skill_root(
+    app: tauri::AppHandle,
+    root_id: String,
+) -> Result<(), SkillRootImportError> {
+    remove_imported_skill_root(&app, root_id)
 }
 
 #[tauri::command]

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -110,7 +110,9 @@ pub enum WindowType {
     Day,
     Week,
     Month,
+    ThreeMonths,
     Year,
+    All,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -35,6 +35,7 @@ pub enum SkillRootImportErrorCode {
     PathNotFound,
     NotDirectory,
     DuplicateId,
+    NotFound,
     ReadFailed,
     WriteFailed,
 }

--- a/apps/rig/src-tauri/src/skills/root_store.rs
+++ b/apps/rig/src-tauri/src/skills/root_store.rs
@@ -71,6 +71,25 @@ pub fn import_skill_root_from_path(
     Ok(imported_skill_root_to_skill_root(imported))
 }
 
+pub fn remove_imported_skill_root(
+    app: &AppHandle,
+    root_id: String,
+) -> Result<(), SkillRootImportError> {
+    let mut imported_roots = load_imported_skill_roots(app)?;
+    let root_count = imported_roots.len();
+
+    imported_roots.retain(|root| root.id != root_id);
+
+    if imported_roots.len() == root_count {
+        return Err(SkillRootImportError {
+            code: SkillRootImportErrorCode::NotFound,
+            message: format!("Imported skill root not found: {}", root_id),
+        });
+    }
+
+    save_imported_skill_roots(app, &imported_roots)
+}
+
 fn load_imported_skill_roots(
     app: &AppHandle,
 ) -> Result<Vec<ImportedSkillRoot>, SkillRootImportError> {

--- a/apps/rig/src-tauri/src/skills/usage.rs
+++ b/apps/rig/src-tauri/src/skills/usage.rs
@@ -127,7 +127,9 @@ fn usage_window_start(now: DateTime<Utc>, window: WindowType) -> DateTime<Utc> {
         WindowType::Day => now - Duration::hours(24),
         WindowType::Week => now - Duration::days(7),
         WindowType::Month => now - Duration::days(30),
+        WindowType::ThreeMonths => now - Duration::days(90),
         WindowType::Year => now - Duration::days(365),
+        WindowType::All => DateTime::<Utc>::from(std::time::UNIX_EPOCH),
     }
 }
 
@@ -137,8 +139,8 @@ fn build_skill_usage_tendencies(
     bucket_type: BucketType,
     now: DateTime<Utc>,
 ) -> Vec<SkillUsageSeries> {
-    let start = usage_window_start(now, window);
     let bucket_duration = bucket_duration(bucket_type);
+    let start = usage_window_start(now, window);
     let bucket_count = bucket_count(start, now, bucket_duration);
     let mut tendencies = HashMap::<String, Vec<u32>>::new();
 
@@ -182,5 +184,5 @@ fn bucket_count(start: DateTime<Utc>, end: DateTime<Utc>, bucket_duration: Durat
     let seconds = (end - start).num_seconds();
     let bucket_seconds = bucket_duration.num_seconds();
 
-    ((seconds + bucket_seconds - 1) / bucket_seconds) as usize
+    (((seconds + bucket_seconds - 1) / bucket_seconds) as usize).max(1)
 }

--- a/apps/rig/src/app/navigation.ts
+++ b/apps/rig/src/app/navigation.ts
@@ -1,0 +1,22 @@
+import { startTransition, useState } from 'react';
+
+export const appPaths = {
+  skills: 'skills',
+  dashboard: 'dashboard',
+} as const;
+
+export type AppPath = (typeof appPaths)[keyof typeof appPaths];
+
+export const useAppNavigation = (initialPath: AppPath = appPaths.skills) => {
+  const [currentPath, setCurrentPath] = useState<AppPath>(initialPath);
+
+  const navigate = (path: AppPath) => {
+    startTransition(() => setCurrentPath(path));
+  };
+
+  return {
+    currentPath,
+    navigate,
+    isCurrentPath: (path: AppPath) => currentPath === path,
+  };
+};

--- a/apps/rig/src/app/root.tsx
+++ b/apps/rig/src/app/root.tsx
@@ -1,54 +1,94 @@
-import { useState } from 'react';
-import { SkillContentViewer } from '@/features/skills/components/SkillContentViewer';
-import { SkillSidebar } from '@/features/skills/components/SkillSidebar';
+import { appPaths, useAppNavigation } from '@/app/navigation';
+import { DashboardRoot } from '@/features/dashboard/components/DashboardRoot';
 import { RepositorySelector } from '@/features/skills/components/RepositorySelector';
-import type { Skill } from '@/features/skills/types';
+import { SkillRoot } from '@/features/skills/components/SkillRoot';
 import { useImportSkillRoot } from '@/features/skills/useImportSkillRoot';
 import { useSkillRepositorySelection } from '@/features/skills/useSkillRepositorySelection';
 import { useSkillRoots } from '@/features/skills/useSkillRoots';
-import { ContentLayout } from '@/layouts/ContentLayout';
 import { HeaderLayout } from '@/layouts/HeaderLayout';
-import { SidebarLayout } from '@/layouts/SidebarLayout';
 
 export const Root = () => {
-  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
+  const navigation = useAppNavigation();
 
   const { data: roots = [] } = useSkillRoots();
   const repositorySelection = useSkillRepositorySelection({
     roots,
-    onRepositoryChange: () => setSelectedSkill(null),
+    onRepositoryChange: () => undefined,
   });
   const importSkillRoot = useImportSkillRoot({
     onImported: importedRoot =>
       repositorySelection.selectRepository(importedRoot.id),
   });
+  const renderCurrentPath = () => {
+    switch (navigation.currentPath) {
+      case appPaths.skills:
+        return (
+          <SkillRoot
+            key={repositorySelection.selectedRepositoryId}
+            roots={repositorySelection.visibleRoots}
+          />
+        );
+      case appPaths.dashboard:
+        return <DashboardRoot roots={repositorySelection.visibleRoots} />;
+    }
+  };
 
   return (
     <main className='flex h-dvh flex-col overflow-hidden bg-background text-foreground'>
       <HeaderLayout>
-        <RepositorySelector
-          roots={roots}
-          selectedRepositoryId={repositorySelection.selectedRepositoryId}
-          isOpen={repositorySelection.isOpen}
-          isImporting={importSkillRoot.isImporting}
-          onOpenChange={repositorySelection.setIsOpen}
-          onSelectRepository={repositorySelection.selectRepository}
-          onImportRepository={importSkillRoot.importFromFolder}
-        />
-      </HeaderLayout>
-      <div className='flex min-h-0 flex-1'>
-        <SidebarLayout>
-          <SkillSidebar
-            roots={repositorySelection.visibleRoots}
-            selectedSkill={selectedSkill}
-            onSelectSkill={setSelectedSkill}
+        <div className='flex w-full items-center justify-between pr-4'>
+          <RepositorySelector
+            roots={roots}
+            selectedRepositoryId={repositorySelection.selectedRepositoryId}
+            isOpen={repositorySelection.isOpen}
+            isImporting={importSkillRoot.isImporting}
+            onOpenChange={repositorySelection.setIsOpen}
+            onSelectRepository={repositorySelection.selectRepository}
+            onImportRepository={importSkillRoot.importFromFolder}
           />
-        </SidebarLayout>
 
-        <ContentLayout>
-          <SkillContentViewer skill={selectedSkill} />
-        </ContentLayout>
-      </div>
+          <div className='flex rounded-xl border bg-muted/40 p-1'>
+            <ViewToggleButton
+              label='Skills'
+              isSelected={navigation.isCurrentPath(appPaths.skills)}
+              onClick={() => navigation.navigate(appPaths.skills)}
+            />
+            <ViewToggleButton
+              label='Dashboard'
+              isSelected={navigation.isCurrentPath(appPaths.dashboard)}
+              onClick={() => navigation.navigate(appPaths.dashboard)}
+            />
+          </div>
+        </div>
+      </HeaderLayout>
+      {renderCurrentPath()}
     </main>
+  );
+};
+
+interface ViewToggleButtonProps {
+  label: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const ViewToggleButton = ({
+  label,
+  isSelected,
+  onClick,
+}: ViewToggleButtonProps) => {
+  return (
+    <button
+      type='button'
+      aria-pressed={isSelected}
+      onClick={onClick}
+      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+        isSelected
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {label}
+    </button>
   );
 };

--- a/apps/rig/src/features/dashboard/components/DashboardRoot.tsx
+++ b/apps/rig/src/features/dashboard/components/DashboardRoot.tsx
@@ -1,0 +1,17 @@
+import { ContentLayout } from '@/layouts/ContentLayout';
+import type { SkillRoot } from '@/features/skills/types';
+import { SkillUsageDashboard } from './SkillUsageDashboard';
+
+interface DashboardRootProps {
+  roots: SkillRoot[];
+}
+
+export const DashboardRoot = ({ roots }: DashboardRootProps) => {
+  return (
+    <div className='flex min-h-0 flex-1'>
+      <ContentLayout>
+        <SkillUsageDashboard roots={roots} />
+      </ContentLayout>
+    </div>
+  );
+};

--- a/apps/rig/src/features/dashboard/components/SkillUsageDashboard.tsx
+++ b/apps/rig/src/features/dashboard/components/SkillUsageDashboard.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { Effect } from 'effect';
+import { listSkills, listSkillUsages } from '@/features/skills/api';
+import type { SkillRoot, WindowType } from '@/features/skills/types';
+
+const dashboardWindows: Array<{
+  value: WindowType;
+  label: string;
+  summaryLabel: string;
+  unusedLabel: string;
+}> = [
+  {
+    value: 'week',
+    label: '7 days',
+    summaryLabel: 'last 7 days',
+    unusedLabel: 'Unused in 7 days',
+  },
+  {
+    value: 'month',
+    label: '30 days',
+    summaryLabel: 'last 30 days',
+    unusedLabel: 'Unused in 30 days',
+  },
+  {
+    value: 'threeMonths',
+    label: '3 months',
+    summaryLabel: 'last 3 months',
+    unusedLabel: 'Unused in 3 months',
+  },
+  {
+    value: 'year',
+    label: '1 year',
+    summaryLabel: 'last 1 year',
+    unusedLabel: 'Unused in 1 year',
+  },
+  {
+    value: 'all',
+    label: 'All',
+    summaryLabel: 'all time',
+    unusedLabel: 'Unused overall',
+  },
+];
+
+interface SkillUsageDashboardProps {
+  roots: SkillRoot[];
+}
+
+export const SkillUsageDashboard = ({ roots }: SkillUsageDashboardProps) => {
+  const [selectedWindow, setSelectedWindow] = useState<WindowType>('month');
+  const selectedWindowConfig =
+    dashboardWindows.find(window => window.value === selectedWindow) ??
+    dashboardWindows[1];
+  const repositoryRoot =
+    roots.length === 1 && roots[0]?.kind === 'repository' ? roots[0] : null;
+
+  const skillQueries = useQueries({
+    queries: roots.map(root => ({
+      queryKey: ['skills', root.path],
+      queryFn: () => Effect.runPromise(listSkills(root.path)),
+    })),
+  });
+
+  const { data: skillUsages = [], isLoading: isUsageLoading } = useQuery({
+    queryKey: ['skill-usages', selectedWindow],
+    queryFn: () => Effect.runPromise(listSkillUsages(selectedWindow)),
+  });
+
+  const skills = skillQueries.flatMap(query => query.data ?? []);
+  const isSkillsLoading = skillQueries.some(query => query.isLoading);
+  const usageByName = new Map(skillUsages.map(usage => [usage.name, usage]));
+  const skillNames = new Set(skills.map(skill => skill.name));
+  const visibleUsages = skillUsages
+    .filter(usage => skillNames.size === 0 || skillNames.has(usage.name))
+    .toSorted((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  const totalFires = visibleUsages.reduce(
+    (total, usage) => total + usage.count,
+    0,
+  );
+  const activeSkills = visibleUsages.filter(usage => usage.count > 0).length;
+  const topSkill = visibleUsages[0];
+  const maxCount = topSkill?.count ?? 0;
+  const unusedSkills = Math.max(skills.length - activeSkills, 0);
+  const leastUsedSkills = skills
+    .map(skill => ({
+      id: skill.id,
+      name: skill.name,
+      relativePath: skill.relativePath,
+      count: usageByName.get(skill.name)?.count ?? 0,
+    }))
+    .filter(skill => skill.count <= 5)
+    .toSorted((a, b) => a.count - b.count || a.name.localeCompare(b.name));
+  const isLoading = isSkillsLoading || isUsageLoading;
+
+  return (
+    <div className='h-full overflow-auto px-8 py-7'>
+      <div className='mx-auto flex max-w-6xl flex-col gap-6'>
+        <div>
+          <div className='flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between'>
+            <div>
+              <p className='text-sm font-medium text-muted-foreground'>
+                {repositoryRoot ? repositoryRoot.label : 'Global'} ·{' '}
+                {selectedWindowConfig.summaryLabel}
+              </p>
+              <h1 className='mt-1 text-3xl font-semibold tracking-tight'>
+                Skill Usage Dashboard
+              </h1>
+            </div>
+
+            <div className='flex flex-col gap-2 sm:items-end'>
+              <div className='flex flex-wrap gap-2'>
+                {dashboardWindows.map(window => (
+                  <DashboardFilterButton
+                    key={window.value}
+                    label={window.label}
+                    isSelected={selectedWindow === window.value}
+                    onClick={() => setSelectedWindow(window.value)}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className='grid gap-4 md:grid-cols-4'>
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className='h-32 animate-pulse rounded-2xl border bg-muted/40'
+              />
+            ))}
+          </div>
+        ) : (
+          <>
+            <div className='grid gap-4 md:grid-cols-4'>
+              <DashboardStat label='Total fires' value={totalFires} />
+              <DashboardStat label='Active skills' value={activeSkills} />
+              <DashboardStat label='Tracked skills' value={skills.length} />
+              <DashboardStat
+                label={selectedWindowConfig.unusedLabel}
+                value={unusedSkills}
+              />
+            </div>
+
+            <div className='grid gap-4 lg:grid-cols-[1.2fr_0.8fr]'>
+              <section className='rounded-2xl border bg-card p-5'>
+                <div className='mb-5 flex items-center justify-between gap-4'>
+                  <div>
+                    <h2 className='text-lg font-semibold'>Most used skills</h2>
+                    <p className='text-sm text-muted-foreground'>
+                      Combined usage from the selected repository context.
+                    </p>
+                  </div>
+                  <p className='text-sm font-medium text-muted-foreground'>
+                    {visibleUsages.length} used
+                  </p>
+                </div>
+
+                <div className='space-y-3'>
+                  {visibleUsages.length === 0 ? (
+                    <p className='rounded-xl border border-dashed p-6 text-sm text-muted-foreground'>
+                      No usage events found yet.
+                    </p>
+                  ) : (
+                    visibleUsages.slice(0, 8).map((usage, index) => {
+                      const width =
+                        maxCount > 0 ? (usage.count / maxCount) * 100 : 0;
+
+                      return (
+                        <div key={usage.name} className='space-y-2'>
+                          <div className='flex items-center justify-between gap-3 text-sm'>
+                            <div className='flex min-w-0 items-center gap-2'>
+                              <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-medium text-muted-foreground'>
+                                {index + 1}
+                              </span>
+                              <span className='truncate font-medium'>
+                                {usage.name}
+                              </span>
+                            </div>
+                            <span className='font-mono text-xs text-muted-foreground'>
+                              {usage.count}×
+                            </span>
+                          </div>
+                          <div className='h-2 overflow-hidden rounded-full bg-muted'>
+                            <div
+                              className='h-full rounded-full bg-foreground'
+                              style={{ width: `${width}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              </section>
+
+              <section className='rounded-2xl border bg-card p-5'>
+                <div className='mb-5'>
+                  <div className='flex items-center gap-2'>
+                    <span className='size-2 rounded-full bg-amber-400' />
+                    <h2 className='text-lg font-semibold'>Least used skills</h2>
+                  </div>
+                  <p className='mt-1 text-sm text-muted-foreground'>
+                    5 fires or fewer. Candidates to review, archive, or remove.
+                  </p>
+                </div>
+
+                {leastUsedSkills.length === 0 ? (
+                  <p className='rounded-xl border border-dashed p-6 text-sm text-muted-foreground'>
+                    No skills found in this repository context.
+                  </p>
+                ) : (
+                  <div className='space-y-3'>
+                    {leastUsedSkills.slice(0, 8).map(skill => (
+                      <div
+                        key={skill.id}
+                        className='rounded-xl border bg-background p-3'
+                      >
+                        <div className='flex items-center justify-between gap-3'>
+                          <p className='min-w-0 truncate text-sm font-medium'>
+                            {skill.name}
+                          </p>
+                          <span className='shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 font-mono text-xs font-medium text-amber-600 dark:text-amber-300'>
+                            {skill.count}×
+                          </span>
+                        </div>
+                        <p className='mt-1 truncate font-mono text-xs text-muted-foreground'>
+                          {skill.relativePath}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface DashboardFilterButtonProps {
+  label: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const DashboardFilterButton = ({
+  label,
+  isSelected,
+  onClick,
+}: DashboardFilterButtonProps) => {
+  return (
+    <button
+      type='button'
+      aria-pressed={isSelected}
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+        isSelected
+          ? 'border-foreground bg-foreground text-background'
+          : 'border-border bg-background text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {label}
+    </button>
+  );
+};
+
+interface DashboardStatProps {
+  label: string;
+  value: number | string;
+}
+
+const DashboardStat = ({ label, value }: DashboardStatProps) => {
+  return (
+    <div className='rounded-2xl border bg-card p-5'>
+      <p className='text-sm font-medium text-muted-foreground'>{label}</p>
+      <p className='mt-3 text-3xl font-semibold tracking-tight'>{value}</p>
+    </div>
+  );
+};

--- a/apps/rig/src/features/skills/api.ts
+++ b/apps/rig/src/features/skills/api.ts
@@ -72,6 +72,39 @@ export const importSkillRoot = Effect.fn('importSkillRoot')(function* (
   });
 });
 
+export class RemoveSkillRootError extends Data.TaggedError(
+  'RemoveSkillRootError',
+)<{
+  kind: 'InvokeError' | 'SkillRootImportError';
+  cause: unknown;
+}> {}
+
+export const removeSkillRoot = Effect.fn('removeSkillRoot')(function* (
+  rootId: string,
+) {
+  yield* Effect.tryPromise({
+    try: () => invoke<void>('remove_skill_root', { rootId }),
+    catch: error => error,
+  }).pipe(
+    Effect.catchAll(error => {
+      const removeError = SkillRootImportErrorSchema.safeParse(error);
+
+      if (removeError.success) {
+        return Effect.fail(
+          new RemoveSkillRootError({
+            kind: 'SkillRootImportError',
+            cause: removeError.data,
+          }),
+        );
+      }
+
+      return Effect.fail(
+        new RemoveSkillRootError({ kind: 'InvokeError', cause: error }),
+      );
+    }),
+  );
+});
+
 export class ListSkillsError extends Data.TaggedError('ListSkillsError')<{
   kind: 'InvokeError' | 'SkillListingError' | 'ZodParseError';
   rootPath: string;

--- a/apps/rig/src/features/skills/components/RepositorySelector.tsx
+++ b/apps/rig/src/features/skills/components/RepositorySelector.tsx
@@ -45,7 +45,10 @@ export const RepositorySelector = ({
             </span>
           </span>
 
-          <ChevronsUpDown size={16} className='shrink-0 text-muted-foreground' />
+          <ChevronsUpDown
+            size={16}
+            className='shrink-0 text-muted-foreground'
+          />
         </button>
       </PopoverTrigger>
 

--- a/apps/rig/src/features/skills/components/RepositorySelector.tsx
+++ b/apps/rig/src/features/skills/components/RepositorySelector.tsx
@@ -1,6 +1,8 @@
-import { cn, Popover, PopoverContent, PopoverTrigger } from '@allin/ui';
+import { cn, Popover, PopoverContent, PopoverTrigger, toast } from '@allin/ui';
 import { Check, ChevronsUpDown, Folder, Home, Plus } from 'lucide-react';
+import { useEffect } from 'react';
 import type { SkillRoot } from '../types';
+import { useRemoveSkillRoot } from '../useRemoveSkillRoot';
 
 const GLOBAL_REPOSITORY_ID = 'global';
 
@@ -28,6 +30,27 @@ export const RepositorySelector = ({
     root => root.id === selectedRepositoryId,
   );
   const selectedLabel = selectedRepository?.label ?? 'Global';
+  const { removeRoot } = useRemoveSkillRoot();
+
+  useEffect(() => {
+    if (
+      selectedRepository?.kind === 'repository' &&
+      !selectedRepository?.exists
+    ) {
+      toast.error(`${selectedLabel} repository does not exist.`, {
+        description: 'This repository is removed from the list.',
+      });
+
+      removeRoot(selectedRepositoryId);
+      onSelectRepository(GLOBAL_REPOSITORY_ID);
+    }
+  }, [
+    onSelectRepository,
+    removeRoot,
+    selectedLabel,
+    selectedRepository,
+    selectedRepositoryId,
+  ]);
 
   return (
     <Popover open={isOpen} onOpenChange={onOpenChange}>

--- a/apps/rig/src/features/skills/components/SkillList.tsx
+++ b/apps/rig/src/features/skills/components/SkillList.tsx
@@ -86,7 +86,7 @@ export const SkillList = ({
                 aria-current={isSelected ? 'true' : undefined}
                 onClick={() => onSelectSkill(skill)}
                 className={cn(
-                  'flex w-full min-w-0 items-center gap-3 rounded-xl border px-3 py-3 text-left transition-colors',
+                  'flex w-full max-w-76 mx-auto min-w-0 items-center gap-3 rounded-xl border px-3 py-3 text-left transition-colors',
                   'hover:bg-accent hover:text-accent-foreground',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   isSelected

--- a/apps/rig/src/features/skills/components/SkillRoot.tsx
+++ b/apps/rig/src/features/skills/components/SkillRoot.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { ContentLayout } from '@/layouts/ContentLayout';
+import { SidebarLayout } from '@/layouts/SidebarLayout';
+import { SkillContentViewer } from './SkillContentViewer';
+import { SkillSidebar } from './SkillSidebar';
+import type { Skill, SkillRoot as SkillRootModel } from '../types';
+
+interface SkillRootProps {
+  roots: SkillRootModel[];
+}
+
+export const SkillRoot = ({ roots }: SkillRootProps) => {
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
+
+  return (
+    <div className='flex min-h-0 flex-1'>
+      <SidebarLayout>
+        <SkillSidebar
+          roots={roots}
+          selectedSkill={selectedSkill}
+          onSelectSkill={setSelectedSkill}
+        />
+      </SidebarLayout>
+
+      <ContentLayout>
+        <SkillContentViewer skill={selectedSkill} />
+      </ContentLayout>
+    </div>
+  );
+};

--- a/apps/rig/src/features/skills/types.ts
+++ b/apps/rig/src/features/skills/types.ts
@@ -58,7 +58,14 @@ export const SkillUsageErrorSchema = z.object({
   message: z.string(),
 });
 
-export const WindowTypeSchema = z.enum(['day', 'week', 'month', 'year']);
+export const WindowTypeSchema = z.enum([
+  'day',
+  'week',
+  'month',
+  'threeMonths',
+  'year',
+  'all',
+]);
 
 export const BucketTypeSchema = z.enum(['hour', 'day', 'month']);
 

--- a/apps/rig/src/features/skills/types.ts
+++ b/apps/rig/src/features/skills/types.ts
@@ -42,6 +42,7 @@ export const SkillRootImportErrorCodeSchema = z.enum([
   'pathNotFound',
   'notDirectory',
   'duplicateId',
+  'notFound',
   'readFailed',
   'writeFailed',
 ]);

--- a/apps/rig/src/features/skills/useRemoveSkillRoot.ts
+++ b/apps/rig/src/features/skills/useRemoveSkillRoot.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Effect } from 'effect';
+import { removeSkillRoot } from './api';
+import { skillRootsQueryKey } from './useSkillRoots';
+
+export const useRemoveSkillRoot = ({
+  onRemoved,
+}: {
+  onRemoved?: (rootId: string) => void;
+} = {}) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (rootId: string) => Effect.runPromise(removeSkillRoot(rootId)),
+    onSuccess: (_, rootId) => {
+      onRemoved?.(rootId);
+      void queryClient.invalidateQueries({ queryKey: skillRootsQueryKey });
+    },
+  });
+
+  return {
+    removeRoot: mutation.mutate,
+    isRemoving: mutation.isPending,
+  };
+};

--- a/apps/rig/src/features/skills/useSkillRepositorySelection.ts
+++ b/apps/rig/src/features/skills/useSkillRepositorySelection.ts
@@ -28,10 +28,7 @@ export const useSkillRepositorySelection = ({
   };
 };
 
-const getVisibleRoots = (
-  roots: SkillRoot[],
-  selectedRepositoryId: string,
-) => {
+const getVisibleRoots = (roots: SkillRoot[], selectedRepositoryId: string) => {
   if (selectedRepositoryId === GLOBAL_REPOSITORY_ID) {
     return roots.filter(root => root.kind === 'default');
   }


### PR DESCRIPTION
## Summary
- add a skill usage dashboard with path-like app navigation
- split dashboard and skills into separate root components
- support additional usage windows: 3 months and all time
- add imported skill root removal core logic and frontend hook

## Verification
- cargo fmt && cargo check
- pnpm --filter desktop-app check-ts