### PR TITLE
fix: dedupe fetched skills by name

### DIFF
--- a/apps/rig/src/features/dashboard/components/SkillUsageDashboard.tsx
+++ b/apps/rig/src/features/dashboard/components/SkillUsageDashboard.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Effect } from 'effect';
-import { listSkills, listSkillUsages } from '@/features/skills/api';
+import { listSkillUsages } from '@/features/skills/api';
 import type { SkillRoot, WindowType } from '@/features/skills/types';
+import { useFetchSkills } from '@/features/skills/useFetchSkills';
 
 const dashboardWindows: Array<{
   value: WindowType;
@@ -54,20 +55,13 @@ export const SkillUsageDashboard = ({ roots }: SkillUsageDashboardProps) => {
   const repositoryRoot =
     roots.length === 1 && roots[0]?.kind === 'repository' ? roots[0] : null;
 
-  const skillQueries = useQueries({
-    queries: roots.map(root => ({
-      queryKey: ['skills', root.path],
-      queryFn: () => Effect.runPromise(listSkills(root.path)),
-    })),
-  });
+  const { skills, isLoading: isSkillsLoading } = useFetchSkills(roots);
 
   const { data: skillUsages = [], isLoading: isUsageLoading } = useQuery({
     queryKey: ['skill-usages', selectedWindow],
     queryFn: () => Effect.runPromise(listSkillUsages(selectedWindow)),
   });
 
-  const skills = skillQueries.flatMap(query => query.data ?? []);
-  const isSkillsLoading = skillQueries.some(query => query.isLoading);
   const usageByName = new Map(skillUsages.map(usage => [usage.name, usage]));
   const skillNames = new Set(skills.map(skill => skill.name));
   const visibleUsages = skillUsages

--- a/apps/rig/src/features/skills/components/SkillSidebar.tsx
+++ b/apps/rig/src/features/skills/components/SkillSidebar.tsx
@@ -1,7 +1,8 @@
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Effect } from 'effect';
-import { listSkills, listSkillUsages, listSkillUsagesTendency } from '../api';
+import { listSkillUsages, listSkillUsagesTendency } from '../api';
 import type { Skill, SkillRoot } from '../types';
+import { useFetchSkills } from '../useFetchSkills';
 import { SkillList } from './SkillList';
 
 interface SkillSidebarProps {
@@ -15,12 +16,7 @@ export const SkillSidebar = ({
   selectedSkill,
   onSelectSkill,
 }: SkillSidebarProps) => {
-  const skillQueries = useQueries({
-    queries: roots.map(root => ({
-      queryKey: ['skills', root.path],
-      queryFn: () => Effect.runPromise(listSkills(root.path)),
-    })),
-  });
+  const { skills, isLoading, error } = useFetchSkills(roots);
 
   const { data: skillUsages = [] } = useQuery({
     queryKey: ['skill-usages', 'month'],
@@ -31,10 +27,6 @@ export const SkillSidebar = ({
     queryKey: ['skill-usages-tendency', 'month', 'day'],
     queryFn: () => Effect.runPromise(listSkillUsagesTendency('month', 'day')),
   });
-
-  const skills = skillQueries.flatMap(query => query.data ?? []);
-  const isLoading = skillQueries.some(query => query.isLoading);
-  const error = skillQueries.find(query => query.error)?.error;
 
   return (
     <SkillList

--- a/apps/rig/src/features/skills/useFetchSkills.ts
+++ b/apps/rig/src/features/skills/useFetchSkills.ts
@@ -22,6 +22,8 @@ const filterDuplicate = (skills: Skill[]) => {
   const names = new Set<string>();
 
   return skills.filter(skill => {
+    // Users may sync the same skill into multiple coding-service roots,
+    // such as .claude/skills and .agents/skills. Keep the first one shown.
     if (names.has(skill.name)) {
       return false;
     }

--- a/apps/rig/src/features/skills/useFetchSkills.ts
+++ b/apps/rig/src/features/skills/useFetchSkills.ts
@@ -1,0 +1,32 @@
+import { useQueries } from '@tanstack/react-query';
+import { Effect } from 'effect';
+import { listSkills } from './api';
+import type { Skill, SkillRoot } from './types';
+
+export const useFetchSkills = (roots: SkillRoot[]) => {
+  const skillQueries = useQueries({
+    queries: roots.map(root => ({
+      queryKey: ['skills', root.path],
+      queryFn: () => Effect.runPromise(listSkills(root.path)),
+    })),
+  });
+
+  return {
+    skills: filterDuplicate(skillQueries.flatMap(query => query.data ?? [])),
+    isLoading: skillQueries.some(query => query.isLoading),
+    error: skillQueries.find(query => query.error)?.error ?? null,
+  };
+};
+
+const filterDuplicate = (skills: Skill[]) => {
+  const names = new Set<string>();
+
+  return skills.filter(skill => {
+    if (names.has(skill.name)) {
+      return false;
+    }
+
+    names.add(skill.name);
+    return true;
+  });
+};


### PR DESCRIPTION
## Summary
- add a shared `useFetchSkills` hook for loading skills from multiple roots
- dedupe fetched skills by `skill.name` in one place
- update the skills sidebar and dashboard to use the shared hook

## Why
Some users use multiple coding services at the same time, so the same skill can appear in more than one root such as `.claude/skills` and `.agents/skills`. Dedupe prevents the same skill from being shown multiple times in the Rig UI.

## Verification
- pnpm --filter desktop-app check-ts