### PR TITLE
Add app update dialog

### DIFF
--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -1,8 +1,7 @@
-mod app_updates;
-
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, RunEvent, WindowEvent};
 mod skills;
+mod update;
 
 const OPEN_APP_UPDATE_EVENT: &str = "open-app-update";
 const CHECK_FOR_UPDATES_MENU_ID: &str = "check-for-updates";
@@ -78,7 +77,7 @@ pub fn run() {
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())
                 .map_err(|e| e.to_string())?;
-            app.manage(app_updates::PendingUpdate(Mutex::new(None)));
+            app.manage(update::state::PendingUpdate(Mutex::new(None)));
 
             #[cfg(target_os = "macos")]
             setup_macos_menu(app)?;
@@ -93,8 +92,8 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            app_updates::fetch_update,
-            app_updates::install_update,
+            update::commands::fetch_update,
+            update::commands::install_update,
             skills::commands::import_skill_root,
             skills::commands::list_skill_roots,
             skills::commands::list_skills,

--- a/apps/rig/src-tauri/src/update/commands.rs
+++ b/apps/rig/src-tauri/src/update/commands.rs
@@ -1,17 +1,8 @@
-use std::sync::Mutex;
-
-use serde::Serialize;
 use tauri::{AppHandle, State};
-use tauri_plugin_updater::{Update, UpdaterExt};
+use tauri_plugin_updater::UpdaterExt;
 
-pub struct PendingUpdate(pub Mutex<Option<Update>>);
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UpdateMetadata {
-    version: String,
-    current_version: String,
-}
+use super::models::UpdateMetadata;
+use super::state::PendingUpdate;
 
 #[tauri::command]
 pub async fn fetch_update(
@@ -41,7 +32,10 @@ pub async fn fetch_update(
 }
 
 #[tauri::command]
-pub async fn install_update(pending_update: State<'_, PendingUpdate>) -> Result<(), String> {
+pub async fn install_update(
+    app: AppHandle,
+    pending_update: State<'_, PendingUpdate>,
+) -> Result<(), String> {
     let update = {
         let mut guard = pending_update
             .0
@@ -57,5 +51,5 @@ pub async fn install_update(pending_update: State<'_, PendingUpdate>) -> Result<
         .await
         .map_err(|e| e.to_string())?;
 
-    Ok(())
+    app.restart();
 }

--- a/apps/rig/src-tauri/src/update/mod.rs
+++ b/apps/rig/src-tauri/src/update/mod.rs
@@ -1,0 +1,3 @@
+pub mod commands;
+pub mod models;
+pub mod state;

--- a/apps/rig/src-tauri/src/update/models.rs
+++ b/apps/rig/src-tauri/src/update/models.rs
@@ -1,0 +1,6 @@
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateMetadata {
+    pub version: String,
+    pub current_version: String,
+}

--- a/apps/rig/src-tauri/src/update/state.rs
+++ b/apps/rig/src-tauri/src/update/state.rs
@@ -1,0 +1,5 @@
+use std::sync::Mutex;
+
+use tauri_plugin_updater::Update;
+
+pub struct PendingUpdate(pub Mutex<Option<Update>>);

--- a/apps/rig/src-tauri/tauri.conf.json
+++ b/apps/rig/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "ALLIN",
+  "productName": "Rig",
   "version": "26.4.7",
-  "identifier": "sh.allin.app",
+  "identifier": "sh.rig.app",
   "build": {
     "frontendDist": "../out",
     "devUrl": "http://localhost:3000",
@@ -12,7 +12,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://raw.githubusercontent.com/gaki2/ALLIN/main/apps/tauri/latest.json"
+        "https://raw.githubusercontent.com/builder-mafia/rig/main/apps/rig/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEE1N0U2MkNEQ0Q1QzQwODkKUldTSlFGek56V0orcFdlV3kxMlNCZmQ3YjN2Uktzc2ZleGRkSVIyb1ZNcVBCSUNwaDloREY4aTQK"
     }
@@ -21,7 +21,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "title": "ALLIN",
+        "title": "Rig",
         "width": 1600,
         "height": 1000,
         "resizable": true,

--- a/apps/rig/src/app/page.tsx
+++ b/apps/rig/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Toaster } from '@allin/ui';
+import { AppUpdateDialog } from '@/features/update/components/AppUpdateDialog';
 import { QueryProvider } from '@/lib/QueryProvider';
 import { Root } from './root';
 
@@ -8,6 +9,7 @@ const Home = () => {
   return (
     <QueryProvider>
       <Root />
+      <AppUpdateDialog />
       <Toaster richColors duration={3000} theme='light' />
     </QueryProvider>
   );

--- a/apps/rig/src/features/update/api.ts
+++ b/apps/rig/src/features/update/api.ts
@@ -1,0 +1,39 @@
+import { invoke } from '@tauri-apps/api/core';
+import { Data, Effect } from 'effect';
+import { UpdateMetadataSchema } from './types';
+
+export class FetchUpdateError extends Data.TaggedError('FetchUpdateError')<{
+  kind: 'InvokeError' | 'ZodParseError';
+  cause: unknown;
+}> {}
+
+export const fetchUpdate = Effect.fn('fetchUpdate')(function* () {
+  const result = yield* Effect.tryPromise({
+    try: () => invoke<unknown>('fetch_update'),
+    catch: error =>
+      new FetchUpdateError({ kind: 'InvokeError', cause: error }),
+  });
+
+  if (result == null) {
+    return null;
+  }
+
+  return yield* Effect.try({
+    try: () => UpdateMetadataSchema.parse(result),
+    catch: error =>
+      new FetchUpdateError({ kind: 'ZodParseError', cause: error }),
+  });
+});
+
+export class InstallUpdateError extends Data.TaggedError('InstallUpdateError')<{
+  kind: 'InvokeError';
+  cause: unknown;
+}> {}
+
+export const installUpdate = Effect.fn('installUpdate')(function* () {
+  yield* Effect.tryPromise({
+    try: () => invoke<void>('install_update'),
+    catch: error =>
+      new InstallUpdateError({ kind: 'InvokeError', cause: error }),
+  });
+});

--- a/apps/rig/src/features/update/components/AppUpdateDialog.tsx
+++ b/apps/rig/src/features/update/components/AppUpdateDialog.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Spinner,
+} from '@allin/ui';
+import { RefreshCw } from 'lucide-react';
+import { useAppUpdate } from '../useAppUpdate';
+
+export const AppUpdateDialog = () => {
+  const appUpdate = useAppUpdate();
+  const isBusy = appUpdate.isChecking || appUpdate.isInstalling;
+
+  return (
+    <Dialog open={appUpdate.isOpen} onOpenChange={appUpdate.setIsOpen}>
+      <DialogContent showCloseButton={!isBusy}>
+        <DialogHeader>
+          <DialogTitle>{getTitle(appUpdate.status)}</DialogTitle>
+          <DialogDescription>{getDescription(appUpdate)}</DialogDescription>
+        </DialogHeader>
+
+        {appUpdate.update != null && appUpdate.status === 'available' ? (
+          <div className='rounded-lg border bg-muted/40 p-3 text-sm'>
+            <div className='flex items-center justify-between gap-3'>
+              <span className='text-muted-foreground'>Current version</span>
+              <span className='font-mono'>{appUpdate.update.currentVersion}</span>
+            </div>
+            <div className='mt-2 flex items-center justify-between gap-3'>
+              <span className='text-muted-foreground'>New version</span>
+              <span className='font-mono font-medium'>{appUpdate.update.version}</span>
+            </div>
+          </div>
+        ) : null}
+
+        {appUpdate.errorMessage != null ? (
+          <p className='rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive'>
+            {appUpdate.errorMessage}
+          </p>
+        ) : null}
+
+        <DialogFooter>
+          {appUpdate.status === 'available' ? (
+            <>
+              <Button
+                type='button'
+                variant='outline'
+                disabled={isBusy}
+                onClick={() => appUpdate.setIsOpen(false)}
+              >
+                Later
+              </Button>
+              <Button
+                type='button'
+                disabled={isBusy}
+                onClick={() => appUpdate.installUpdate()}
+              >
+                {appUpdate.isInstalling ? <Spinner /> : null}
+                Update now
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                type='button'
+                variant='outline'
+                disabled={isBusy}
+                onClick={() => appUpdate.setIsOpen(false)}
+              >
+                Close
+              </Button>
+              <Button
+                type='button'
+                disabled={isBusy}
+                onClick={() => appUpdate.checkForUpdate({ openWhenNone: true })}
+              >
+                {appUpdate.isChecking ? <Spinner /> : <RefreshCw />}
+                Check again
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const getTitle = (status: ReturnType<typeof useAppUpdate>['status']) => {
+  switch (status) {
+    case 'checking':
+      return 'Checking for updates';
+    case 'available':
+      return 'Update available';
+    case 'notAvailable':
+      return 'Rig is up to date';
+    case 'installing':
+      return 'Installing update';
+    case 'error':
+      return 'Update check failed';
+    case 'idle':
+      return 'App updates';
+  }
+};
+
+const getDescription = (appUpdate: ReturnType<typeof useAppUpdate>) => {
+  switch (appUpdate.status) {
+    case 'checking':
+      return 'Looking for a newer version of Rig.';
+    case 'available':
+      return 'A new version is ready to install. Rig will restart after the update is installed.';
+    case 'notAvailable':
+      return 'You are already running the latest available version.';
+    case 'installing':
+      return 'Downloading and installing the update. Rig will restart automatically.';
+    case 'error':
+      return 'Rig could not check for updates. Try again in a moment.';
+    case 'idle':
+      return 'Check whether a newer version of Rig is available.';
+  }
+};

--- a/apps/rig/src/features/update/types.ts
+++ b/apps/rig/src/features/update/types.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const UpdateMetadataSchema = z.object({
+  version: z.string(),
+  currentVersion: z.string(),
+});
+
+export type UpdateMetadata = z.infer<typeof UpdateMetadataSchema>;

--- a/apps/rig/src/features/update/useAppUpdate.ts
+++ b/apps/rig/src/features/update/useAppUpdate.ts
@@ -1,0 +1,98 @@
+import { useMutation } from '@tanstack/react-query';
+import { listen } from '@tauri-apps/api/event';
+import { Effect } from 'effect';
+import { useEffect, useState } from 'react';
+import { fetchUpdate, installUpdate } from './api';
+import type { UpdateMetadata } from './types';
+
+const OPEN_APP_UPDATE_EVENT = 'open-app-update';
+
+type UpdateStatus =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'notAvailable'
+  | 'installing'
+  | 'error';
+
+interface CheckUpdateOptions {
+  openWhenNone?: boolean;
+}
+
+export const useAppUpdate = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [status, setStatus] = useState<UpdateStatus>('idle');
+  const [update, setUpdate] = useState<UpdateMetadata | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const checkMutation = useMutation({
+    mutationFn: (_options: CheckUpdateOptions = {}) =>
+      Effect.runPromise(fetchUpdate()),
+    onMutate: () => {
+      setStatus('checking');
+      setErrorMessage(null);
+    },
+    onSuccess: (nextUpdate, options) => {
+      setUpdate(nextUpdate);
+
+      if (nextUpdate == null) {
+        setStatus('notAvailable');
+        setIsOpen(options?.openWhenNone === true);
+        return;
+      }
+
+      setStatus('available');
+      setIsOpen(true);
+    },
+    onError: (error, options) => {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+      setIsOpen(options?.openWhenNone === true);
+    },
+  });
+
+  const installMutation = useMutation({
+    mutationFn: () => Effect.runPromise(installUpdate()),
+    onMutate: () => {
+      setStatus('installing');
+      setErrorMessage(null);
+    },
+    onError: error => {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    },
+  });
+
+  const checkForUpdate = (options: CheckUpdateOptions = {}) => {
+    if (options.openWhenNone === true) {
+      setIsOpen(true);
+    }
+
+    checkMutation.mutate(options);
+  };
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void checkForUpdate();
+
+    const unlistenPromise = listen(OPEN_APP_UPDATE_EVENT, () => {
+      checkForUpdate({ openWhenNone: true });
+    });
+
+    return () => {
+      void unlistenPromise.then(unlisten => unlisten());
+    };
+  }, []);
+
+  return {
+    isOpen,
+    setIsOpen,
+    status,
+    update,
+    errorMessage,
+    checkForUpdate,
+    installUpdate: installMutation.mutate,
+    isChecking: checkMutation.isPending,
+    isInstalling: installMutation.isPending,
+  };
+};


### PR DESCRIPTION
## Summary
- move Tauri updater commands into a dedicated update module
- add shadcn-based update dialog and frontend update API/hook
- restart the app after update installation

<img width="3200" height="2000" alt="rig-update-dialog-pr147" src="https://github.com/user-attachments/assets/9ec2fe90-21c3-4899-a3ed-25423c8fe1e4" />



## Testing
- pnpm --filter desktop-app check-ts
- cargo check