### PR TITLE
Align Rig branding and release paths

### DIFF
--- a/apps/rig/scripts/build-prod.mjs
+++ b/apps/rig/scripts/build-prod.mjs
@@ -111,7 +111,7 @@ const buildReleaseDownloadUrl = (version, artifactPath, currentLatestJson) => {
     return currentUrl.replace(/\/download\/v[^/]+\//, `/download/v${version}/`);
   }
 
-  return `https://github.com/gaki2/ALLIN/releases/download/v${version}/${artifactName}`;
+  return `https://github.com/builder-mafia/rig/releases/download/v${version}/${artifactName}`;
 };
 
 const updateLatestJson = async (version, artifactPath) => {

--- a/apps/rig/scripts/upload-release-artifacts.mjs
+++ b/apps/rig/scripts/upload-release-artifacts.mjs
@@ -71,7 +71,7 @@ const main = async () => {
     'release',
     'bundle',
     'dmg',
-    `ALLIN_${version}_aarch64.dmg`,
+    `Rig_${version}_aarch64.dmg`,
   );
   const updaterPath = path.join(
     appDir,
@@ -80,7 +80,7 @@ const main = async () => {
     'release',
     'bundle',
     'macos',
-    'ALLIN.app.tar.gz',
+    'Rig.app.tar.gz',
   );
   const signaturePath = `${updaterPath}.sig`;
 

--- a/apps/rig/src-tauri/Cargo.lock
+++ b/apps/rig/src-tauri/Cargo.lock
@@ -3,7 +3,7 @@
 version = 3
 
 [[package]]
-name = "ALLIN"
+name = "Rig"
 version = "26.4.7"
 dependencies = [
  "aisdk",

--- a/apps/rig/src-tauri/Cargo.toml
+++ b/apps/rig/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "ALLIN"
+name = "Rig"
 version = "26.4.7"
-description = "Allin"
+description = "Rig"
 authors = ["you"]
 license = ""
 repository = ""

--- a/apps/rig/src-tauri/src/lib.rs
+++ b/apps/rig/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ const CHECK_FOR_UPDATES_MENU_ID: &str = "check-for-updates";
 fn setup_macos_menu(app: &tauri::App) -> tauri::Result<()> {
     use tauri::menu::{AboutMetadata, MenuBuilder, SubmenuBuilder};
 
-    let app_menu = SubmenuBuilder::new(app, "ALLIN")
+    let app_menu = SubmenuBuilder::new(app, "Rig")
         .about(Some(AboutMetadata::default()))
         .separator()
         .text(CHECK_FOR_UPDATES_MENU_ID, "Check for Updates...")

--- a/apps/rig/src-tauri/src/main.rs
+++ b/apps/rig/src-tauri/src/main.rs
@@ -4,5 +4,3 @@
 fn main() {
     app_lib::run();
 }
-
-// sqlite3 Library/Application\ Support/com.tauri.dev/ALLIN.sqlite

--- a/apps/rig/src-tauri/tauri.local.conf.json
+++ b/apps/rig/src-tauri/tauri.local.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "ALLIN DEV",
+  "productName": "Rig DEV",
   "bundle": {
     "icon": ["icons/dev_icon.png", "icons/dev_icon.icns"]
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ALLIN",
+  "name": "Rig",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "description": "Claude Code plugin for tracking Rig skill usage locally",
   "author": {
-    "name": "ALLIN"
+    "name": "Rig"
   },
-  "repository": "https://github.com/allin-sh/rig",
+  "repository": "https://github.com/builder-mafia/rig",
   "license": "MIT",
   "keywords": ["claude-code", "rig", "skills", "usage-tracking"]
 }


### PR DESCRIPTION
## Summary
- update remaining ALLIN labels to Rig in desktop/package metadata
- update macOS release artifact names for Rig bundles
- point release download URL generation at builder-mafia/rig

## Testing
- pnpm --filter desktop-app check-ts
- cargo check