### PR TITLE
Release v26.6.4 and document setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,18 @@ Rig gives you one focused desktop workspace for finding, editing, and understand
 
 Rig is currently in MVP development.
 
-## Install Rig
+## Usage
 
-Download the latest macOS app from the [Rig releases page](https://github.com/builder-mafia/rig/releases).
+### 1. Install Rig
 
-Open the downloaded `.dmg`, drag Rig into Applications, then launch Rig.
+1. Download the latest macOS app from the [Rig releases page](https://github.com/builder-mafia/rig/releases).
+2. Open the downloaded `.dmg` file.
+3. Drag Rig into Applications.
+4. Launch Rig.
 
-## Set Up Usage Tracking
+### 2. Install Plugins
 
-Rig can show skill usage when OpenCode or Claude Code writes usage events to the local Rig log file:
+Rig tracks skill usage when OpenCode or Claude Code writes usage events to:
 
 ```text
 ~/.rig/usage.jsonl
@@ -39,9 +42,9 @@ Rig can show skill usage when OpenCode or Claude Code writes usage events to the
 
 The desktop app reads this file automatically.
 
-## OpenCode Plugin
+#### OpenCode
 
-Add the `rig-opencode` plugin to your OpenCode config. The config file is usually at `~/.config/opencode/opencode.json`.
+Add `rig-opencode` to your OpenCode config. The config file is usually at `~/.config/opencode/opencode.json`.
 
 ```json
 {
@@ -52,25 +55,17 @@ Add the `rig-opencode` plugin to your OpenCode config. The config file is usuall
 
 Restart OpenCode after saving the config. OpenCode installs npm plugins automatically at startup.
 
-## Claude Code Plugin
+#### Claude Code
 
-Install the Rig Claude Code plugin into your Claude Code skills directory:
+Use the [Rig Claude Code plugin folder](https://github.com/builder-mafia/rig/tree/main/packages/claude-code-plugin).
 
-```bash
-tmpdir=$(mktemp -d)
-git clone --depth 1 https://github.com/builder-mafia/rig.git "$tmpdir/rig"
-mkdir -p ~/.claude/skills
-rm -rf ~/.claude/skills/rig-claude-code
-cp -R "$tmpdir/rig/packages/claude-code-plugin" ~/.claude/skills/rig-claude-code
+Put the contents of that folder into your local Claude Code plugin setup folder, for example:
+
+```text
+~/.claude/skills/rig-claude-code
 ```
 
-Restart Claude Code after installing the plugin:
-
-```bash
-claude
-```
-
-After setup, use skills normally in OpenCode or Claude Code. Rig will pick up new usage events from `~/.rig/usage.jsonl`.
+Restart Claude Code after copying the plugin.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,55 @@ Rig gives you one focused desktop workspace for finding, editing, and understand
 
 Rig is currently in MVP development.
 
+## Install Rig
+
+Download the latest macOS app from the [Rig releases page](https://github.com/builder-mafia/rig/releases).
+
+Open the downloaded `.dmg`, drag Rig into Applications, then launch Rig.
+
+## Set Up Usage Tracking
+
+Rig can show skill usage when OpenCode or Claude Code writes usage events to the local Rig log file:
+
+```text
+~/.rig/usage.jsonl
+```
+
+The desktop app reads this file automatically.
+
+## OpenCode Plugin
+
+Add the `rig-opencode` plugin to your OpenCode config. The config file is usually at `~/.config/opencode/opencode.json`.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["rig-opencode"]
+}
+```
+
+Restart OpenCode after saving the config. OpenCode installs npm plugins automatically at startup.
+
+## Claude Code Plugin
+
+Install the Rig Claude Code plugin into your Claude Code skills directory:
+
+```bash
+tmpdir=$(mktemp -d)
+git clone --depth 1 https://github.com/builder-mafia/rig.git "$tmpdir/rig"
+mkdir -p ~/.claude/skills
+rm -rf ~/.claude/skills/rig-claude-code
+cp -R "$tmpdir/rig/packages/claude-code-plugin" ~/.claude/skills/rig-claude-code
+```
+
+Restart Claude Code after installing the plugin:
+
+```bash
+claude
+```
+
+After setup, use skills normally in OpenCode or Claude Code. Rig will pick up new usage events from `~/.rig/usage.jsonl`.
+
 ## Development
 
 ```bash

--- a/apps/rig/latest.json
+++ b/apps/rig/latest.json
@@ -1,11 +1,11 @@
 {
-  "version": "26.4.7",
-  "notes": "Release 26.4.7",
-  "pub_date": "2026-04-07T12:27:57.038Z",
+  "version": "26.6.4",
+  "notes": "Release 26.6.4",
+  "pub_date": "2026-06-03T16:54:35.816Z",
   "platforms": {
     "darwin-aarch64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTSlFGek56V0orcGR5L1NNWGUzRm91UHpXWXJnWHdsRVAwZzZkdGtlUEZNTFQ3R01RNVBjZTdhM2Z1ZnMvbWt5ODdSYnZ2dTZ1Q285d0JWMHo4cGNEbVpZOUhUbnVkYlFBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc1NTY0ODc3CWZpbGU6QUxMSU4uYXBwLnRhci5negpjc3BBd3dwZ3VkVmdLMDVRYkpDbno0MUZkSlZTckdpbWdLT2wyd1V5dXg5Y09lUXlzeFY0Z3lCTmVSMzhRRzQ5dHFnU2JybXpRT1BlaUpHeEdWMmhCUT09Cg==",
-      "url": "https://github.com/gaki2/ALLIN/releases/download/v26.4.7/ALLIN.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTSlFGek56V0orcGFFVk9HeFo3QnVtbGFJVzFaTGtMZldPTDBsbC9qMmIybWxoOWxpbEkwYmlROGxHTDFMY3pnWWxpeWxVMlZ3dGpFVkJpWklaNEQ5NFdkRmN4bjFDcUF3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwNTA1Njc1CWZpbGU6UmlnLmFwcC50YXIuZ3oKVXJhbHd0MGJ2YUZmd0c3SG5JYUVTTWlyb2VScWFjSEYvb2Fub2w4ZkpiZ016TTRxYm0zUk51a0tHdmhGT29QUHBsNmpsdVZ3VGtUN2tONkxRYm9RQnc9PQo=",
+      "url": "https://github.com/builder-mafia/rig/releases/download/v26.6.4/Rig.app.tar.gz"
     }
   }
 }

--- a/apps/rig/package.json
+++ b/apps/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-app",
-  "version": "26.4.7",
+  "version": "26.6.4",
   "private": true,
   "scripts": {
     "build:prod": "node ./scripts/build-prod.mjs && pnpm run release:upload",

--- a/apps/rig/scripts/build-prod.mjs
+++ b/apps/rig/scripts/build-prod.mjs
@@ -101,15 +101,8 @@ const ensureUpdaterSignature = async artifactPath => {
   }
 };
 
-const buildReleaseDownloadUrl = (version, artifactPath, currentLatestJson) => {
+const buildReleaseDownloadUrl = (version, artifactPath) => {
   const artifactName = path.basename(artifactPath);
-  const currentUrl =
-    currentLatestJson?.platforms?.['darwin-aarch64']?.url ??
-    currentLatestJson?.platforms?.['darwin-x86_64']?.url;
-
-  if (typeof currentUrl === 'string' && currentUrl.length > 0) {
-    return currentUrl.replace(/\/download\/v[^/]+\//, `/download/v${version}/`);
-  }
 
   return `https://github.com/builder-mafia/rig/releases/download/v${version}/${artifactName}`;
 };
@@ -127,7 +120,7 @@ const updateLatestJson = async (version, artifactPath) => {
     ...(latestJson.platforms ?? {}),
     [platformKey]: {
       signature,
-      url: buildReleaseDownloadUrl(version, artifactPath, latestJson),
+      url: buildReleaseDownloadUrl(version, artifactPath),
     },
   };
 

--- a/apps/rig/src-tauri/Cargo.lock
+++ b/apps/rig/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Rig"
-version = "26.4.7"
+version = "26.6.4"
 dependencies = [
  "aisdk",
  "base64 0.22.1",

--- a/apps/rig/src-tauri/Cargo.toml
+++ b/apps/rig/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Rig"
-version = "26.4.7"
+version = "26.6.4"
 description = "Rig"
 authors = ["you"]
 license = ""

--- a/apps/rig/src-tauri/tauri.conf.json
+++ b/apps/rig/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rig",
-  "version": "26.4.7",
+  "version": "26.6.4",
   "identifier": "sh.rig.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Description
- release Rig v26.6.4 and update Tauri updater metadata
- make release URL generation use the current Rig artifact name and builder-mafia/rig repository
- document the user setup flow with app installation first, then OpenCode and Claude Code plugin setup

## Why
Users need a clear install path from GitHub Releases and simple plugin setup instructions for tracking skill usage from OpenCode and Claude Code.

## Screenshots (if UI)
N/A

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore

## Testing
- cargo check
- pnpm --filter desktop-app check-ts