### PR TITLE
feat: add Claude plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "rig",
+  "owner": {
+    "name": "Rig"
+  },
+  "description": "Claude Code plugins for Rig",
+  "plugins": [
+    {
+      "name": "rig-claude-code",
+      "displayName": "Rig Claude Code",
+      "source": "./packages/claude-code-plugin",
+      "description": "Track Claude Code skill usage locally for Rig",
+      "author": {
+        "name": "Rig"
+      },
+      "homepage": "https://github.com/builder-mafia/rig/tree/main/packages/claude-code-plugin",
+      "repository": "https://github.com/builder-mafia/rig",
+      "license": "MIT",
+      "keywords": ["claude-code", "rig", "skills", "usage-tracking"],
+      "category": "productivity",
+      "tags": ["claude-code", "skills", "usage-tracking"],
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,8 +18,7 @@
       "license": "MIT",
       "keywords": ["claude-code", "rig", "skills", "usage-tracking"],
       "category": "productivity",
-      "tags": ["claude-code", "skills", "usage-tracking"],
-      "version": "0.1.0"
+      "tags": ["claude-code", "skills", "usage-tracking"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -57,15 +57,14 @@ Restart OpenCode after saving the config. OpenCode installs npm plugins automati
 
 #### Claude Code
 
-Use the [Rig Claude Code plugin folder](https://github.com/builder-mafia/rig/tree/main/packages/claude-code-plugin).
-
-Put the contents of that folder into your local Claude Code plugin setup folder, for example:
+Add the Rig Claude Code marketplace and install the plugin:
 
 ```text
-~/.claude/skills/rig-claude-code
+/plugin marketplace add builder-mafia/rig
+/plugin install rig-claude-code@rig
 ```
 
-Restart Claude Code after copying the plugin.
+For local development, use the repository path with `/plugin marketplace add ./path/to/rig`.
 
 ## Development
 

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "rig-claude-code",
+  "displayName": "Rig Claude Code",
   "version": "0.1.0",
   "description": "Claude Code plugin for tracking Rig skill usage locally",
   "author": {
@@ -7,5 +8,6 @@
   },
   "repository": "https://github.com/builder-mafia/rig",
   "license": "MIT",
-  "keywords": ["claude-code", "rig", "skills", "usage-tracking"]
+  "keywords": ["claude-code", "rig", "skills", "usage-tracking"],
+  "hooks": "./hooks/hooks.json"
 }

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -4,17 +4,18 @@ Claude Code plugin for tracking Rig skill usage locally.
 
 ## Installation
 
-Copy this entire folder into your Claude Code skills directory:
+Add the Rig marketplace and install the plugin:
 
-```sh
-mkdir -p ~/.claude/skills
-cp -R ./packages/claude-code-plugin ~/.claude/skills/rig-claude-code
+```text
+/plugin marketplace add builder-mafia/rig
+/plugin install rig-claude-code@rig
 ```
 
-Then start Claude Code normally:
+If you are testing from a local checkout, add the repository path instead:
 
-```sh
-claude
+```text
+/plugin marketplace add ./path/to/rig
+/plugin install rig-claude-code@rig
 ```
 
 The plugin records skill usage to:


### PR DESCRIPTION
## Summary
- add a Claude Code marketplace manifest for the Rig plugin
- expose the Claude Code plugin hooks through plugin.json
- update installation docs to use /plugin marketplace add and /plugin install

## Tests
- claude plugin validate .
- claude plugin validate ./packages/claude-code-plugin
- pnpm --filter rig-claude-code check
- git diff --check