### PR TITLE
fix: avoid duplicate Claude plugin hooks

### DIFF
--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "repository": "https://github.com/builder-mafia/rig",
   "license": "MIT",
-  "keywords": ["claude-code", "rig", "skills", "usage-tracking"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["claude-code", "rig", "skills", "usage-tracking"]
 }


### PR DESCRIPTION
## Summary
- remove manifest.hooks for the standard hooks/hooks.json file
- rely on Claude Code automatic loading for the standard hooks location
- fixes duplicate hooks file detection after installing rig-claude-code from the marketplace

## Tests
- claude plugin validate .
- claude plugin validate ./packages/claude-code-plugin
- pnpm --filter rig-claude-code check
- git diff --check