### PR TITLE
feat: add provider metadata to skill roots

### DIFF
--- a/apps/rig/src-tauri/src/skills/commands.rs
+++ b/apps/rig/src-tauri/src/skills/commands.rs
@@ -2,9 +2,9 @@ use std::fs;
 use std::path::{Component, Path};
 
 use super::models::{
-    BucketType, Skill, SkillDeletionError, SkillDeletionErrorCode, SkillListingError, SkillRoot,
-    SkillRootDefinition, SkillRootImportError, SkillRootKind, SkillUsage, SkillUsageError,
-    SkillUsageEvent, SkillUsageSeries, WindowType,
+    BucketType, Skill, SkillDeletionError, SkillDeletionErrorCode, SkillListingError,
+    SkillProvider, SkillRoot, SkillRootDefinition, SkillRootImportError, SkillRootKind,
+    SkillScopeKind, SkillUsage, SkillUsageError, SkillUsageEvent, SkillUsageSeries, WindowType,
 };
 use super::root_store::{
     import_skill_root_from_path, list_imported_skill_roots, remove_imported_skill_root,
@@ -21,19 +21,49 @@ const SKILL_USAGE_LOG_PATH: &str = "~/.rig/usage.jsonl";
 
 pub const SKILL_ROOT_DEFINITIONS: &[SkillRootDefinition] = &[
     SkillRootDefinition {
-        id: "agents-global",
+        id: "global-agents",
         path: "~/.agents/skills",
-        label: "Agents Global Skills",
+        label: "Agents",
+        provider: SkillProvider::Agents,
+        scope_id: "global",
+        scope_label: "Global",
+        scope_kind: SkillScopeKind::Global,
     },
     SkillRootDefinition {
-        id: "opencode-global",
+        id: "global-opencode",
         path: "~/.config/opencode/skills",
-        label: "OpenCode Global Skills",
+        label: "OpenCode",
+        provider: SkillProvider::OpenCode,
+        scope_id: "global",
+        scope_label: "Global",
+        scope_kind: SkillScopeKind::Global,
     },
     SkillRootDefinition {
-        id: "claude-global",
+        id: "global-claude",
         path: "~/.claude/skills",
-        label: "Claude Global Skills",
+        label: "Claude",
+        provider: SkillProvider::Claude,
+        scope_id: "global",
+        scope_label: "Global",
+        scope_kind: SkillScopeKind::Global,
+    },
+    SkillRootDefinition {
+        id: "global-hermes",
+        path: "~/.hermes/skills",
+        label: "Hermes",
+        provider: SkillProvider::Hermes,
+        scope_id: "global",
+        scope_label: "Global",
+        scope_kind: SkillScopeKind::Global,
+    },
+    SkillRootDefinition {
+        id: "global-cursor",
+        path: "~/.cursor/skills",
+        label: "Cursor",
+        provider: SkillProvider::Cursor,
+        scope_id: "global",
+        scope_label: "Global",
+        scope_kind: SkillScopeKind::Global,
     },
 ];
 
@@ -50,6 +80,10 @@ pub fn list_skill_roots(app: tauri::AppHandle) -> Vec<SkillRoot> {
                 label: definition.label.to_string(),
                 exists: path.exists(),
                 kind: SkillRootKind::Default,
+                provider: definition.provider.clone(),
+                scope_id: definition.scope_id.to_string(),
+                scope_label: definition.scope_label.to_string(),
+                scope_kind: definition.scope_kind.clone(),
             }
         })
         .collect::<Vec<_>>();
@@ -75,24 +109,29 @@ pub fn remove_skill_root(
 }
 
 #[tauri::command]
-pub fn list_skills(root_path: String) -> Result<Vec<Skill>, SkillListingError> {
-    let path = expand_path(root_path.as_str());
+pub fn list_skills(root: SkillRoot) -> Result<Vec<Skill>, SkillListingError> {
+    let path = expand_path(root.path.as_str());
 
     if !path.exists() {
         return Err(SkillListingError {
             code: SkillListingErrorCode::PathNotFound,
-            message: format!("Skill root path does not exist: {}", root_path),
+            message: format!("Skill root path does not exist: {}", root.path),
         });
     }
 
     if !path.is_dir() {
         return Err(SkillListingError {
             code: SkillListingErrorCode::NotDirectory,
-            message: format!("Skill root path is not a directory: {}", root_path),
+            message: format!("Skill root path is not a directory: {}", root.path),
         });
     }
 
-    return list_skills_from_root(&path);
+    let root = SkillRoot {
+        path: path.to_string_lossy().to_string(),
+        ..root
+    };
+
+    return list_skills_from_root(&root);
 }
 
 #[tauri::command]
@@ -197,4 +236,24 @@ pub fn list_skill_usages_tendency(
         window.unwrap_or(WindowType::Week),
         bucket_type.unwrap_or(BucketType::Hour),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_roots_include_hermes_global_provider_root() {
+        let hermes_root = SKILL_ROOT_DEFINITIONS
+            .iter()
+            .find(|definition| definition.id == "global-hermes")
+            .expect("Hermes global root should be registered");
+
+        assert_eq!(hermes_root.path, "~/.hermes/skills");
+        assert_eq!(hermes_root.label, "Hermes");
+        assert_eq!(hermes_root.provider, SkillProvider::Hermes);
+        assert_eq!(hermes_root.scope_id, "global");
+        assert_eq!(hermes_root.scope_label, "Global");
+        assert_eq!(hermes_root.scope_kind, SkillScopeKind::Global);
+    }
 }

--- a/apps/rig/src-tauri/src/skills/models.rs
+++ b/apps/rig/src-tauri/src/skills/models.rs
@@ -2,6 +2,28 @@ pub struct SkillRootDefinition {
     pub id: &'static str,
     pub path: &'static str,
     pub label: &'static str,
+    pub provider: SkillProvider,
+    pub scope_id: &'static str,
+    pub scope_label: &'static str,
+    pub scope_kind: SkillScopeKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SkillProvider {
+    Agents,
+    Claude,
+    OpenCode,
+    Hermes,
+    Cursor,
+    Repository,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SkillScopeKind {
+    Global,
+    Repository,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -19,6 +41,10 @@ pub struct SkillRoot {
     pub label: String,
     pub exists: bool,
     pub kind: SkillRootKind,
+    pub provider: SkillProvider,
+    pub scope_id: String,
+    pub scope_label: String,
+    pub scope_kind: SkillScopeKind,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -59,6 +85,12 @@ pub struct Skill {
     pub is_valid: bool,
     pub validation_error: Option<SkillValidationError>,
     pub updated_at: Option<String>,
+    pub provider: SkillProvider,
+    pub scope_id: String,
+    pub scope_label: String,
+    pub scope_kind: SkillScopeKind,
+    pub root_id: String,
+    pub root_label: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/apps/rig/src-tauri/src/skills/root_store.rs
+++ b/apps/rig/src-tauri/src/skills/root_store.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
 use super::models::{
-    ImportedSkillRoot, SkillRoot, SkillRootImportError, SkillRootImportErrorCode, SkillRootKind,
+    ImportedSkillRoot, SkillProvider, SkillRoot, SkillRootImportError, SkillRootImportErrorCode,
+    SkillRootKind, SkillScopeKind,
 };
 
 const SKILL_ROOTS_FILE_NAME: &str = "skill-roots.json";
@@ -148,12 +149,20 @@ fn skill_roots_file_path(app: &AppHandle) -> Result<PathBuf, SkillRootImportErro
 
 fn imported_skill_root_to_skill_root(root: ImportedSkillRoot) -> SkillRoot {
     let path = PathBuf::from(&root.path);
+    let scope_label = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| root.label.clone());
 
     SkillRoot {
         id: root.id,
-        path: root.path,
+        path: root.path.clone(),
         label: root.label,
         exists: path.exists(),
         kind: SkillRootKind::Repository,
+        provider: SkillProvider::Repository,
+        scope_id: root.path,
+        scope_label,
+        scope_kind: SkillScopeKind::Repository,
     }
 }

--- a/apps/rig/src-tauri/src/skills/scanner.rs
+++ b/apps/rig/src-tauri/src/skills/scanner.rs
@@ -4,18 +4,20 @@ use std::path::{Path, PathBuf};
 use walkdir::{DirEntry, WalkDir};
 
 use super::models::{
-    Skill, SkillListingError, SkillListingErrorCode, SkillValidationError, SkillValidationErrorCode,
+    Skill, SkillListingError, SkillListingErrorCode, SkillRoot, SkillValidationError,
+    SkillValidationErrorCode,
 };
 use super::parser::parse_skill_file_content;
 
 const IGNORED_DIRECTORY_NAMES: &[&str] = &[".archive", ".backups", ".git", "node_modules"];
 
-pub fn list_skills_from_root(root_path: &Path) -> Result<Vec<Skill>, SkillListingError> {
+pub fn list_skills_from_root(root: &SkillRoot) -> Result<Vec<Skill>, SkillListingError> {
+    let root_path = Path::new(root.path.as_str());
     let skill_files = collect_skill_files(root_path)?;
 
     Ok(skill_files
         .iter()
-        .map(|skill_file_path| build_skill_from_file(root_path, skill_file_path))
+        .map(|skill_file_path| build_skill_from_file(root, root_path, skill_file_path))
         .collect())
 }
 
@@ -50,7 +52,7 @@ fn is_skill_file(entry: &DirEntry) -> bool {
     entry.file_type().is_file() && entry.file_name() == "SKILL.md"
 }
 
-fn build_skill_from_file(root_path: &Path, skill_file_path: &Path) -> Skill {
+fn build_skill_from_file(root: &SkillRoot, root_path: &Path, skill_file_path: &Path) -> Skill {
     let skill_dir = skill_file_path.parent().unwrap_or(root_path);
     let relative_path = skill_dir
         .strip_prefix(root_path)
@@ -83,6 +85,12 @@ fn build_skill_from_file(root_path: &Path, skill_file_path: &Path) -> Skill {
                 is_valid: true,
                 validation_error: None,
                 updated_at,
+                provider: root.provider.clone(),
+                scope_id: root.scope_id.clone(),
+                scope_label: root.scope_label.clone(),
+                scope_kind: root.scope_kind.clone(),
+                root_id: root.id.clone(),
+                root_label: root.label.clone(),
             },
             Err(validation_error) => Skill {
                 id: relative_path.clone(),
@@ -94,6 +102,12 @@ fn build_skill_from_file(root_path: &Path, skill_file_path: &Path) -> Skill {
                 is_valid: false,
                 validation_error: Some(validation_error),
                 updated_at,
+                provider: root.provider.clone(),
+                scope_id: root.scope_id.clone(),
+                scope_label: root.scope_label.clone(),
+                scope_kind: root.scope_kind.clone(),
+                root_id: root.id.clone(),
+                root_label: root.label.clone(),
             },
         },
         Err(error) => Skill {
@@ -109,6 +123,12 @@ fn build_skill_from_file(root_path: &Path, skill_file_path: &Path) -> Skill {
                 message: format!("Failed to read SKILL.md: {}", error),
             }),
             updated_at,
+            provider: root.provider.clone(),
+            scope_id: root.scope_id.clone(),
+            scope_label: root.scope_label.clone(),
+            scope_kind: root.scope_kind.clone(),
+            root_id: root.id.clone(),
+            root_label: root.label.clone(),
         },
     }
 }

--- a/apps/rig/src/features/skills/api.ts
+++ b/apps/rig/src/features/skills/api.ts
@@ -11,6 +11,7 @@ import {
   SkillUsageEventSchema,
   SkillUsageSchema,
   SkillUsageSeriesSchema,
+  type SkillRoot,
   type WindowType,
 } from './types';
 
@@ -116,9 +117,9 @@ export class ListSkillsError extends Data.TaggedError('ListSkillsError')<{
 // some users don't have claude folder, so we ignore these errors
 const ignoredSkillListingErrorCodes = new Set(['pathNotFound', 'notDirectory']);
 
-export const listSkills = Effect.fn('listSkills')(function* (rootPath: string) {
+export const listSkills = Effect.fn('listSkills')(function* (root: SkillRoot) {
   const result = yield* Effect.tryPromise({
-    try: () => invoke<unknown>('list_skills', { rootPath }),
+    try: () => invoke<unknown>('list_skills', { root }),
     catch: error => error,
   }).pipe(
     Effect.catchAll(error => {
@@ -135,7 +136,7 @@ export const listSkills = Effect.fn('listSkills')(function* (rootPath: string) {
         return Effect.fail(
           new ListSkillsError({
             kind: 'SkillListingError',
-            rootPath,
+            rootPath: root.path,
             cause: listingError.data,
           }),
         );
@@ -144,7 +145,7 @@ export const listSkills = Effect.fn('listSkills')(function* (rootPath: string) {
       return Effect.fail(
         new ListSkillsError({
           kind: 'InvokeError',
-          rootPath,
+          rootPath: root.path,
           cause: error,
         }),
       );
@@ -156,7 +157,7 @@ export const listSkills = Effect.fn('listSkills')(function* (rootPath: string) {
     catch: error =>
       new ListSkillsError({
         kind: 'ZodParseError',
-        rootPath,
+        rootPath: root.path,
         cause: error,
       }),
   });

--- a/apps/rig/src/features/skills/types.ts
+++ b/apps/rig/src/features/skills/types.ts
@@ -2,12 +2,27 @@ import { z } from 'zod';
 
 export const SkillRootKindSchema = z.enum(['default', 'repository']);
 
+export const SkillProviderSchema = z.enum([
+  'agents',
+  'claude',
+  'openCode',
+  'hermes',
+  'cursor',
+  'repository',
+]);
+
+export const SkillScopeKindSchema = z.enum(['global', 'repository']);
+
 export const SkillRootSchema = z.object({
   id: z.string(),
   path: z.string(),
   label: z.string(),
   exists: z.boolean(),
   kind: SkillRootKindSchema,
+  provider: SkillProviderSchema,
+  scopeId: z.string(),
+  scopeLabel: z.string(),
+  scopeKind: SkillScopeKindSchema,
 });
 
 export const SkillValidationErrorCodeSchema = z.enum([
@@ -93,6 +108,12 @@ export const SkillSchema = z.object({
   isValid: z.boolean(),
   validationError: SkillValidationErrorSchema.nullable(),
   updatedAt: z.string().nullable(),
+  provider: SkillProviderSchema,
+  scopeId: z.string(),
+  scopeLabel: z.string(),
+  scopeKind: SkillScopeKindSchema,
+  rootId: z.string(),
+  rootLabel: z.string(),
 });
 
 export const SkillUsageSchema = z.object({
@@ -114,6 +135,8 @@ export const SkillUsageSeriesSchema = z.object({
 
 export type SkillRoot = z.infer<typeof SkillRootSchema>;
 export type SkillRootKind = z.infer<typeof SkillRootKindSchema>;
+export type SkillProvider = z.infer<typeof SkillProviderSchema>;
+export type SkillScopeKind = z.infer<typeof SkillScopeKindSchema>;
 export type SkillValidationErrorCode = z.infer<
   typeof SkillValidationErrorCodeSchema
 >;

--- a/apps/rig/src/features/skills/useFetchSkills.ts
+++ b/apps/rig/src/features/skills/useFetchSkills.ts
@@ -6,8 +6,8 @@ import type { Skill, SkillRoot } from './types';
 export const useFetchSkills = (roots: SkillRoot[]) => {
   const skillQueries = useQueries({
     queries: roots.map(root => ({
-      queryKey: ['skills', root.path],
-      queryFn: () => Effect.runPromise(listSkills(root.path)),
+      queryKey: ['skills', root.id, root.path, root.exists],
+      queryFn: () => Effect.runPromise(listSkills(root)),
     })),
   });
 


### PR DESCRIPTION
## Summary
- Adds provider and scope metadata to skill roots and skill instances
- Registers Hermes and Cursor as known global skill providers
- Updates the skill listing bridge to pass full root metadata into the scanner

## Test Plan
- [x] pnpm check-ts
- [ ] cargo check --manifest-path apps/rig/src-tauri/Cargo.toml *(blocked locally: missing path dependency /Users/gaki2/Documents/aisdk-rust)*
- [ ] cargo test --manifest-path apps/rig/src-tauri/Cargo.toml skills::commands::tests::default_roots_include_hermes_global_provider_root *(blocked locally: missing path dependency /Users/gaki2/Documents/aisdk-rust)*